### PR TITLE
EOS-18620:[AutoPerf] S3Bench Benchmark run fails due to old binary issue

### DIFF
--- a/performance/AutoPerf/roles/autoPerf/files/cortx-benchmark/s3bench_basic/installS3bench.sh
+++ b/performance/AutoPerf/roles/autoPerf/files/cortx-benchmark/s3bench_basic/installS3bench.sh
@@ -7,10 +7,9 @@ fi
 if [ ! -f "/root/go/bin/s3bench.old" ] ; then
    echo "Installing s3bench tools"
    cd ~; go get github.com/igneous-systems/s3bench
-   cd /root/go/src/github.com/igneous-systems/s3bench; go build
-   yes | cp /root/go/src/github.com/igneous-systems/s3bench/s3bench ~/go/bin/s3bench.old
+   yes | cp ~/go/bin/s3bench ~/go/bin/s3bench.old
 else
-   cp ~/go/bin/s3bench.old s3bench
+   yes | cp ~/go/bin/s3bench.old ~/go/bin/s3bench
    echo "S3benchmark Tools is already configured"
 fi
 


### PR DESCRIPTION
Updated "installS3bench.sh" under path "seagate-tools/performance/AutoPerf/roles/autoPerf/files/cortx-benchmark/s3bench_basic"