### PR TITLE
Fixed fio template undefined issue.

### DIFF
--- a/performance/AutoPerf/autoPerf_Dashboard/gui/src/components/dashboard/dashboard.vue
+++ b/performance/AutoPerf/autoPerf_Dashboard/gui/src/components/dashboard/dashboard.vue
@@ -346,7 +346,7 @@ export default class AutoPerfDashboard extends Vue {
         scriptArgs.operation = this.selectedParameters.operation;
       }
       if (scriptArgs.benchmark === "fio") {
-        scriptArgs.operation = this.selectedParameters.template;
+        scriptArgs.template = this.selectedParameters.template;
       }
       res = await Api.post(apiRegister.script_execution, {
         script_name: "s3workloads",


### PR DESCRIPTION
# UI

 AutoPerf UI : FIO workload fails during execution

## Problem Statement
<pre>
  <code>
    Story Ref (if any):EOS-18937
  </code>
</pre>
## Unit testing on RPM done
<pre>
  <code>
  No
  </code>
</pre>
## Problem Description
<pre>
  <code>
For benchmark FIO, template field is set to undefined which fails the execution
  </code>
</pre>
## Solution/Screenshots
Fixed the issue by setting the template field which got missed.

<pre>
  <code>
  </code>
</pre>

Signed-off-by: Shri Metta <shri.metta@seagate.com>