### PR TITLE
EOS-19275 :[AutoPerf]changed FIO command from PRIMARY to node[1]

### DIFF
--- a/performance/AutoPerf/roles/autoPerf/tasks/main.yml
+++ b/performance/AutoPerf/roles/autoPerf/tasks/main.yml
@@ -126,7 +126,7 @@
    with_items: "{{ groups['clients'] }}"
 
  - name: Fio Running
-   shell: cd /root/cortx-benchmark/fio; ./run_fio.sh {{ PRIMARY }} {{ DURATION }} {{ IOSIZE }} {{ NUMJOBS }} {{ SAMPLE }} {{ TEMPLATE }}
+   shell: cd /root/cortx-benchmark/fio; ./run_fio.sh {{ nodes['1'] }} {{ DURATION }} {{ IOSIZE }} {{ NUMJOBS }} {{ SAMPLE }} {{ TEMPLATE }}
    when: BENCHMARK == "fio"
    delegate_to: "{{ item }}"
    with_items: "{{ groups['clients'] }}"


### PR DESCRIPTION
Changed node's structure from dictionary to list and first node of the cluster as node[1].

[root@ssc-vm-1522 AutoPerf]# git status
# On branch main
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#
#       modified:   roles/autoPerf/tasks/main.yml
#
no changes added to commit (use "git add" and/or "git commit -a")
[root@ssc-vm-1522 AutoPerf]#
[root@ssc-vm-1522 AutoPerf]#
[root@ssc-vm-1522 AutoPerf]# git add roles/autoPerf/tasks/main.yml
[root@ssc-vm-1522 AutoPerf]#
[root@ssc-vm-1522 AutoPerf]# git commit -s -m 'EOS-19275 : changed FIO command from PRIMARY to node[1]'
[main e2fba62] EOS-19275 : changed FIO command from PRIMARY to node[1]
 1 file changed, 1 insertion(+), 1 deletion(-)
[root@ssc-vm-1522 AutoPerf]#
