### PR TITLE
EOS-19585 : functionality of getconfig() updated.

### DIFF
--- a/performance/PerfPro/PerfProBenchmark/cosbench/cosbench_DBupdate.py
+++ b/performance/PerfPro/PerfProBenchmark/cosbench/cosbench_DBupdate.py
@@ -158,30 +158,26 @@ def update_mega_chain(build, version, col):
 
 
 def getconfig():
-    configs = open(Config_path,"r")
-    lines = configs.readlines()
-    key=""
-    dic={}
-    value=""
-    count=0
-    for l in lines:
-        l=l.strip()
-        count+=1
-        if "#END" in l:
-            dic[key]=value
-            break
-        elif "#" in l :
-            continue
-        elif not ":" in l:
-            value=value+l
-        else:
-            dic[key]=value
-            data = l.split(":",1)
-            key = data[0].strip()
-            value = data[1].strip()
-            
-    dic.pop("","key not found")
-    return dic
+    build_url=configs_config.get('BUILD_URL')
+    nodes_list=configs_config.get('NODES')
+    clients_list=configs_config.get('CLIENTS')
+    pc_full=configs_config.get('PC_FULL')
+    overwrite=configs_config.get('OVERWRITE')
+    iteration=configs_config.get('ITERATION')
+    cluster_pass=configs_config.get('CLUSTER_PASS')
+    change_pass=configs_config.get('CHANGE_PASS')
+    prv_cli=configs_config.get('PRVSNR_CLI_REPO')
+    prereq_url=configs_config.get('PREREQ_URL')
+    srv_usr=configs_config.get('SERVICE_USER')
+    srv_pass=configs_config.get('SERVICE_PASS')
+    nfs_serv=configs_config.get('NFS_SERVER')
+    nfs_exp=configs_config.get('NFS_EXPORT')
+    nfs_mp=configs_config.get('NFS_MOUNT_POINT')
+    nfs_fol=configs_config.get('NFS_FOLDER')
+
+    dic={'NODES' :str(nodes_list) , 'CLIENTS' : str(clients_list) ,'BUILD_URL': build_url ,'CLUSTER_PASS': cluster_pass ,'CHANGE_PASS': change_pass ,'PRVSNR_CLI_REPO': prv_cli ,'PREREQ_URL': prereq_url ,'SERVICE_USER': srv_usr ,'SERVICE_PASS': srv_pass , 'PC_FULL': pc_full , 'OVERWRITE':overwrite , 'ITERATION': iteration,'NFS_SERVER': nfs_serv ,'NFS_EXPORT' : nfs_exp ,'NFS_MOUNT_POINT' : nfs_mp , 'NFS_FOLDER' : nfs_fol }
+    return (dic)
+
 
 def main(argv):
     dic = argv[1]

--- a/performance/PerfPro/PerfProBenchmark/hsbench/hsbench_DBupdate.py
+++ b/performance/PerfPro/PerfProBenchmark/hsbench/hsbench_DBupdate.py
@@ -104,30 +104,25 @@ def extract_json(file):
 
 
 def getconfig():
-    configs = open(Config_path,"r")
-    lines = configs.readlines()
-    key=""
-    dic={}
-    value=""
-    count=0
-    for l in lines:
-        l=l.strip()
-        count+=1
-        if "#END" in l:
-            dic[key]=value
-            break
-        elif "#" in l :
-            continue
-        elif not ":" in l:
-            value=value+l
-        else:
-            dic[key]=value
-            data = l.split(":",1)
-            key = data[0].strip()
-            value = data[1].strip()
-            
-    dic.pop("","key not found")
-    return dic
+    build_url=configs_config.get('BUILD_URL')
+    nodes_list=configs_config.get('NODES')
+    clients_list=configs_config.get('CLIENTS')
+    pc_full=configs_config.get('PC_FULL')
+    overwrite=configs_config.get('OVERWRITE')
+    iteration=configs_config.get('ITERATION')
+    cluster_pass=configs_config.get('CLUSTER_PASS')
+    change_pass=configs_config.get('CHANGE_PASS')
+    prv_cli=configs_config.get('PRVSNR_CLI_REPO')
+    prereq_url=configs_config.get('PREREQ_URL')
+    srv_usr=configs_config.get('SERVICE_USER')
+    srv_pass=configs_config.get('SERVICE_PASS')
+    nfs_serv=configs_config.get('NFS_SERVER')
+    nfs_exp=configs_config.get('NFS_EXPORT')
+    nfs_mp=configs_config.get('NFS_MOUNT_POINT')
+    nfs_fol=configs_config.get('NFS_FOLDER')
+
+    dic={'NODES' :str(nodes_list) , 'CLIENTS' : str(clients_list) ,'BUILD_URL': build_url ,'CLUSTER_PASS': cluster_pass ,'CHANGE_PASS': change_pass ,'PRVSNR_CLI_REPO': prv_cli ,'PREREQ_URL': prereq_url ,'SERVICE_USER': srv_usr ,'SERVICE_PASS': srv_pass , 'PC_FULL': pc_full , 'OVERWRITE':overwrite , 'ITERATION': iteration,'NFS_SERVER': nfs_serv ,'NFS_EXPORT' : nfs_exp ,'NFS_MOUNT_POINT' : nfs_mp , 'NFS_FOLDER' : nfs_fol }
+    return (dic)
 
 
 # Function to push data to DB 

--- a/performance/PerfPro/PerfProBenchmark/s3bench_meta/s3bench_DBupdate.py
+++ b/performance/PerfPro/PerfProBenchmark/s3bench_meta/s3bench_DBupdate.py
@@ -189,30 +189,27 @@ def update_mega_chain(build,version, col):
 
 
 def getconfig():
-    configs = open(Config_path,"r")
-    lines = configs.readlines()
-    key=""
-    dic={}
-    value=""
-    count=0
-    for l in lines:
-        l=l.strip()
-        count+=1
-        if "#END" in l:
-            dic[key]=value
-            break
-        elif "#" in l :
-            continue
-        elif not ":" in l:
-            value=value+l
-        else:
-            dic[key]=value
-            data = l.split(":",1)
-            key = data[0].strip()
-            value = data[1].strip()
-            
-    dic.pop("","key not found")
-    return dic
+    build_url=configs_config.get('BUILD_URL')
+    nodes_list=configs_config.get('NODES')
+    clients_list=configs_config.get('CLIENTS')
+    pc_full=configs_config.get('PC_FULL')
+    overwrite=configs_config.get('OVERWRITE')
+    iteration=configs_config.get('ITERATION')
+    cluster_pass=configs_config.get('CLUSTER_PASS')
+    change_pass=configs_config.get('CHANGE_PASS')
+    prv_cli=configs_config.get('PRVSNR_CLI_REPO')
+    prereq_url=configs_config.get('PREREQ_URL')
+    srv_usr=configs_config.get('SERVICE_USER')
+    srv_pass=configs_config.get('SERVICE_PASS')
+    nfs_serv=configs_config.get('NFS_SERVER')
+    nfs_exp=configs_config.get('NFS_EXPORT')
+    nfs_mp=configs_config.get('NFS_MOUNT_POINT')
+    nfs_fol=configs_config.get('NFS_FOLDER')
+
+    dic={'NODES' :str(nodes_list) , 'CLIENTS' : str(clients_list) ,'BUILD_URL': build_url ,'CLUSTER_PASS': cluster_pass ,'CHANGE_PASS': change_pass ,'PRVSNR_CLI_REPO': prv_cli ,'PREREQ_URL': prereq_url ,'SERVICE_USER': srv_usr ,'SERVICE_PASS': srv_pass , 'PC_FULL': pc_full , 'OVERWRITE':overwrite , 'ITERATION': iteration,'NFS_SERVER': nfs_serv ,'NFS_EXPORT' : nfs_exp ,'NFS_MOUNT_POINT' : nfs_mp , 'NFS_FOLDER' : nfs_fol }
+    return (dic)
+
+
 
 def main(argv):
     dic=argv[1]


### PR DESCRIPTION
The function for getconfig() has been updated for 3 off the benchmarking tools (HSbench , CosBench and S3bench)

1. For each of the element in the config.yml a variable is created which gathers the value for the same. 
2. All the values are then created a dictionary with elements as Key 
3. With similar update for addconfiguration.py , the issue of 'Config_ID' remaining 'NA' is resolved. 

sample results : 
cosbench result
Data Inserted : {'Name': 'Cosbench', 'Operation': 'read', 'Build': '161', 'Version': '2.0.0', 'Branch': 'stable', 'OS': 'CentOS Linux release 7.8.2003 (Core)', 'Number_of_Server_Nodes': 3, 'Number_of_Clients': 2, 'Object_Size': '128 MB', 'Buckets': 10, 'Objects': 4096, 'Sessions': 100, 'PKey': '2_S_161_ITR1_3N_2C_0PC_COS_128MB_10_R_100', '_id': ObjectId('608a3dc8552cd1e0efee675c')} {'Log_File': 'w34-128 MB, 10 buckets, 4096 objects, 100 workers, MIXED Workloadtype.csv', 'Operation': 'read', 'IOPS': 3.42, 'Throughput': 437.76, 'Latency': {'Max': 58470.0, 'Avg': 4173.65}, 'HOST': 'ssc-vm-c-0033.colo.seagate.com', **'Config_ID': ObjectId('608a3ba655bce14682b45bf3')**, 'Timestamp': '2021-04-28 23:02:00'}

Data Inserted : {'Name': 'Cosbench', 'Operation': 'write', 'Build': '161', 'Version': '2.0.0', 'Branch': 'stable', 'OS': 'CentOS Linux release 7.8.2003 (Core)', 'Number_of_Server_Nodes': 3, 'Number_of_Clients': 2, 'Object_Size': '128 MB', 'Buckets': 10, 'Objects': 4096, 'Sessions': 100, 'PKey': '2_S_161_ITR1_3N_2C_0PC_COS_128MB_10_W_100', '_id': ObjectId('608a3dc9552cd1e0efee675d')} {'Log_File': 'w34-128 MB, 10 buckets, 4096 objects, 100 workers, MIXED Workloadtype.csv', 'Operation': 'write', 'IOPS': 3.41, 'Throughput': 436.48, 'Latency': {'Max': 130860.0, 'Avg': 25106.43}, 'HOST': 'ssc-vm-c-0033.colo.seagate.com', **'Config_ID': ObjectId('608a3ba655bce14682b45bf3')**, 'Timestamp': '2021-04-28 23:02:01'}

s3bench result
Data Inserted :: {'PKey': '2_S_161_ITR1_3N_2C_0PC_S3B_64Mb_1_W_256'} {'NAME': 'S3bench', 'Log_File': 's3bench_Numclients_256_NS_1000_size_64Mb.log', 'IOPS': 27.606234, 'Throughput': 1766.799, 'Latency': {'Max': 14.44, 'Avg': 8.535, 'Min': 1.803}, 'TTFB': {'Max': 14.44, 'Avg': 8.535, 'Min': 1.803}, 'Timestamp': '2021-04-28 23:02:04', **'Config_ID': ObjectId('608a3ba655bce14682b45bf3')**, 'HOST': 'ssc-vm-c-0033.colo.seagate.com', 'Operation': 'Write', 'Object_Size': '64Mb', 'Build': '161', 'Version': '2.0.0', 'Branch': 'stable', 'OS': 'CentOS Linux release 7.8.2003 (Core)', 'Number_of_Server_Nodes': 3, 'Number_of_Clients': 2, 'PKey': '2_S_161_ITR1_3N_2C_0PC_S3B_64Mb_1_W_256', '_id': ObjectId('608a3dcf55c974af28dc6935')}

Data Inserted :: {'PKey': '2_S_161_ITR1_3N_2C_0PC_S3B_64Mb_1_R_256'} {'NAME': 'S3bench', 'Log_File': 's3bench_Numclients_256_NS_1000_size_64Mb.log', 'IOPS': 65.659188, 'Throughput': 4202.188, 'Latency': {'Max': 6.404, 'Avg': 3.638, 'Min': 0.537}, 'TTFB': {'Max': 4.184, 'Avg': 1.848, 'Min': 0.265}, 'Timestamp': '2021-04-28 23:02:07', **'Config_ID': ObjectId('608a3ba655bce14682b45bf3')**, 'HOST': 'ssc-vm-c-0033.colo.seagate.com', 'Operation': 'Read', 'Object_Size': '64Mb', 'Build': '161', 'Version': '2.0.0', 'Branch': 'stable', 'OS': 'CentOS Linux release 7.8.2003 (Core)', 'Number_of_Server_Nodes': 3, 'Number_of_Clients': 2, 'PKey': '2_S_161_ITR1_3N_2C_0PC_S3B_64Mb_1_R_256', '_id': ObjectId('608a3dd155c974af28dc6937')}
