### PR TITLE
EOS-20181: ADDB Request per second (RPS) metric

### DIFF
--- a/performance/PerfLine/roles/perfline_setup/files/chronometry_v2/rps.py
+++ b/performance/PerfLine/roles/perfline_setup/files/chronometry_v2/rps.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import pandas as pd
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpl_patches
+from pandas.io import sql
+import sqlite3
+import gc
+import sys
+import argparse
+from sys_utils import *
+
+class LocalFigure():
+    def __init__(self, fig):
+        self.fig = fig
+        self.sharex = None
+
+class Handler():
+    NUM_CLI_LAYERS = 3 # S3, MOTR, CRPC
+    NUM_SRV_LAYERS = 4 # SRPC, FOM, BETX, STIO
+    NUM_COLS       = 2 # Queue and RPS
+    SRV_IDX_OFFSET = 3
+    
+    def __init__(self, fiter, avg_window, save_only, hostmap=None):
+        self.cluster_agg = LocalFigure(Figure(f'{fiter.name} cluster-wide RPS',
+                                              self.NUM_CLI_LAYERS + self.NUM_SRV_LAYERS,
+                                              self.NUM_COLS))
+        self.client_agg = LocalFigure(Figure(f'{fiter.name} cluster-wide client RPS',
+                                             self.NUM_CLI_LAYERS, self.NUM_COLS))
+        self.server_agg = LocalFigure(Figure(f'{fiter.name} cluster-wide server RPS',
+                                             self.NUM_SRV_LAYERS, self.NUM_COLS))
+        self.client_hosts = dict()
+        self.server_hosts = dict()
+        self.client_process = dict()
+        self.server_process = dict()
+        self.hostmap = hostmap
+        self.save_only = save_only
+        self.avg_window = avg_window
+        self.fiter = fiter
+
+    def draw_layer(self, fig, ypos, layer, start, stop, avg, pids,
+                   sharex=None, samex=False):
+        queue = Queue(layer, start, stop, pids=pids)
+        rps_in = RPS(layer, start, color='green', 
+                     avg_window=avg, pids=pids)
+        rps_out = RPS(layer, stop, color='red', 
+                      avg_window=avg, pids=pids)
+        queue.calculate()
+        rps_in.calculate()
+        rps_out.calculate()
+        
+        axq = fig.add(queue, ypos, 0, sharex=sharex)
+        if samex:
+            sharex = axq
+        axi = fig.add(rps_in, ypos, 1, sharex=sharex)
+        axo = fig.add(rps_out, ypos, 1, sharex=sharex)
+        return (axq, axi, axo)
+            
+    def process_s3(self, layer):
+        (axq, axi, axo) = self.draw_layer(self.cluster_agg.fig, 0, layer,
+                                          ["START"], ["COMPLETE"],
+                                          self.avg_window, None, samex=True)
+        axq.set_title("Queue length")
+        axi.set_title(f"Requests per second, avg_window {self.avg_window}")
+        self.cluster_agg.sharex = axq
+
+        (axq, axi, axo) = self.draw_layer(self.client_agg.fig, 0, layer,
+                                          ["START"], ["COMPLETE"],
+                                          self.avg_window, None, samex=True)
+        axq.set_title("Queue length")
+        axi.set_title(f"Requests per second, avg_window {self.avg_window}")
+        self.client_agg.sharex = axq
+
+        pids = layer.pids()
+        for pid in pids:
+            lfig = LocalFigure(Figure(f'{self.fiter.name} process {pid} client RPS',
+                                     self.NUM_CLI_LAYERS, self.NUM_COLS))
+            self.client_process[pid] = lfig
+            (axq, axi, axo) = self.draw_layer(lfig.fig, 0, layer,
+                                              ["START"], ["COMPLETE"],
+                                              self.avg_window, [pid], samex=True)
+            axq.set_title("Queue length")
+            axi.set_title(f"Requests per second, avg_window {self.avg_window}")
+            lfig.sharex = axq
+
+        if self.hostmap is not None:
+            for host in self.hostmap.keys():
+                title = f'{self.fiter.name} node {host} client RPS'
+                lfig = LocalFigure(Figure(title,
+                                          self.NUM_CLI_LAYERS, self.NUM_COLS))
+                self.client_hosts[host] = lfig
+                (axq, axi, axo) = self.draw_layer(lfig.fig, 0, layer,
+                                                  ["START"], ["COMPLETE"],
+                                                  self.avg_window, 
+                                                  self.hostmap[host], samex=True)
+    
+                axq.set_title("Queue length")
+                axi.set_title(f"Requests per second, avg_window {self.avg_window}")
+                lfig.sharex = axq
+
+    def process_client(self, layer, start, stop, ypos):
+        (axq, axi, axo) = self.draw_layer(self.cluster_agg.fig, ypos, layer,
+                                          start, stop, self.avg_window, None,
+                                          sharex=self.cluster_agg.sharex)
+
+        (axq, axi, axo) = self.draw_layer(self.client_agg.fig, ypos, layer,
+                                          start, stop, self.avg_window, None,
+                                          sharex=self.client_agg.sharex)
+
+        pids = self.client_process.keys()
+        for pid in pids:
+            lfig = self.client_process[pid]
+            (axq, axi, axo) = self.draw_layer(lfig.fig, ypos, layer,
+                                              start, stop, self.avg_window, [pid],
+                                              lfig.sharex)
+
+        if self.hostmap is not None:
+            for host in self.hostmap.keys():
+                lfig = self.client_hosts[host]
+                (axq, axi, axo) = self.draw_layer(lfig.fig, ypos, layer,
+                                                  start, stop, self.avg_window,
+                                                  self.hostmap[host], lfig.sharex)
+
+    def process_srpc(self, layer, start, stop, ypos):
+        (axq, axi, axo) = self.draw_layer(self.cluster_agg.fig, ypos, layer,
+                                          start, stop, self.avg_window, None,
+                                          sharex=self.cluster_agg.sharex)
+        
+        (axq, axi, axo) = self.draw_layer(self.server_agg.fig, 
+                                          ypos - self.SRV_IDX_OFFSET,
+                                          layer, start, stop, self.avg_window, 
+                                          None, samex=True)
+        axq.set_title("Queue length")
+        axi.set_title(f"Requests per second, avg_window {self.avg_window}")
+        self.server_agg.sharex = axq
+
+        pids = layer.pids()
+        for pid in pids:
+            lfig = LocalFigure(Figure(f'{self.fiter.name} process {pid} server RPS',
+                                     self.NUM_SRV_LAYERS, self.NUM_COLS))
+            self.server_process[pid] = lfig
+            (axq, axi, axo) = self.draw_layer(lfig.fig, 
+                                              ypos - self.SRV_IDX_OFFSET,
+                                              layer, start, stop, self.avg_window, 
+                                              [pid], samex=True)
+            axq.set_title("Queue length")
+            axi.set_title(f"Requests per second, avg_window {self.avg_window}")
+            lfig.sharex = axq
+
+        if self.hostmap is not None:
+            for host in self.hostmap.keys():
+                title = f'{self.fiter.name} node {host} server RPS'
+                lfig = LocalFigure(Figure(title,
+                                          self.NUM_SRV_LAYERS, self.NUM_COLS))
+                self.server_hosts[host] = lfig
+                (axq, axi, axo) = self.draw_layer(lfig.fig,
+                                                  ypos - self.SRV_IDX_OFFSET,
+                                                  layer, start, stop,
+                                                  self.avg_window, 
+                                                  self.hostmap[host], samex=True)
+    
+                axq.set_title("Queue length")
+                axi.set_title(f"Requests per second, avg_window {self.avg_window}")
+                lfig.sharex = axq
+
+
+    def process_server(self, layer, start, stop, ypos):
+        (axq, axi, axo) = self.draw_layer(self.cluster_agg.fig, ypos, layer,
+                                          start, stop, self.avg_window, None,
+                                          sharex=self.cluster_agg.sharex)
+        
+        (axq, axi, axo) = self.draw_layer(self.server_agg.fig, 
+                                          ypos - self.SRV_IDX_OFFSET,
+                                          layer, start, stop, self.avg_window, None,
+                                          sharex=self.server_agg.sharex)
+
+        pids = self.server_process.keys()
+        for pid in pids:
+            lfig = self.server_process[pid]
+            (axq, axi, axo) = self.draw_layer(lfig.fig, 
+                                              ypos - self.SRV_IDX_OFFSET,
+                                              layer, start, stop, self.avg_window, 
+                                              [pid], sharex=lfig.sharex)
+
+        if self.hostmap is not None:
+            for host in self.hostmap.keys():
+                lfig = self.server_hosts[host]
+                (axq, axi, axo) = self.draw_layer(lfig.fig,
+                                                  ypos - self.SRV_IDX_OFFSET, 
+                                                  layer, start, stop, 
+                                                  self.avg_window,
+                                                  self.hostmap[host], lfig.sharex)
+
+    def consume(self, layer):
+        if layer.layer_type == S3:
+            self.process_s3(layer)
+        if layer.layer_type == MOTR_REQ:
+            self.process_client(layer, ["initialised"], ['stable'], 1)
+        if layer.layer_type == CRPC:
+            self.process_client(layer, ['INITIALISED'], ['REPLIED'], 2)
+        if layer.layer_type == SRPC:
+            self.process_srpc(layer, ['INITIALISED'], ['REPLIED'], 3)
+        if layer.layer_type == FOM:
+            self.process_server(layer, ['0', '-1'], ['finish'], 4)
+        if layer.layer_type == STIO:
+            self.process_server(layer, ['M0_AVI_IO_LAUNCH'], ['M0_AVI_AD_ENDIO'], 5)
+        if layer.layer_type == BETX:
+            self.process_server(layer, ['prepare'], ['done'], 6)
+        
+    def done(self):
+        self.cluster_agg.fig.draw()
+        self.cluster_agg.fig.save()
+
+        self.client_agg.fig.draw()
+        self.client_agg.fig.save()
+
+        self.server_agg.fig.draw()
+        self.server_agg.fig.save()
+
+        for pid in self.client_process.keys():
+            fig = self.client_process[pid].fig
+            fig.draw()
+            fig.save()
+
+        for pid in self.server_process.keys():
+            fig = self.server_process[pid].fig
+            fig.draw()
+            fig.save()
+
+        for host in self.client_hosts:
+            fig = self.client_hosts[host].fig
+            fig.draw()
+            fig.save()
+
+        for host in self.server_hosts:
+            fig = self.server_hosts[host].fig
+            fig.draw()
+            fig.save()
+            
+        if not self.save_only:
+            self.cluster_agg.fig.show()
+
+def pandas_init():
+    pd.set_option('display.max_rows', 500)
+    pd.set_option('display.max_columns', 500)
+    pd.set_option('display.width', 1000)
+    pd.set_option('display.expand_frame_repr', False)
+    pd.set_option('display.float_format', lambda x: '%.2f' % x)
+
+def pandas_fini():
+    pass
+
+def calculate(conn, fiter, handler):
+    s3all = Layer(S3, conn)
+    s3 = fiter.run(s3all)
+    handler.consume(s3)
+    del s3all
+    gc.collect()
+    
+    rel = Relation(S3_TO_CLIENT, conn)
+    motr_all = Layer(MOTR_REQ, conn)
+    motr = rel.sieve(s3, motr_all)
+    handler.consume(motr)
+
+    del rel
+    del motr_all
+    del s3
+    gc.collect()
+
+    ioo_all = Layer(IOO, conn)
+    rel = Relation(CLIENT_TO_IOO, conn)
+    ioo = rel.sieve(motr, ioo_all)
+    del ioo_all
+    del rel
+    gc.collect()
+
+    cob_all = Layer(COB, conn)
+    rel = Relation(CLIENT_TO_COB, conn)
+    cob = rel.sieve(motr, cob_all)
+    del cob_all
+    del rel
+    gc.collect()
+
+    dix_all = Layer(DIX, conn)
+    rel_dix = Relation(CLIENT_TO_DIX, conn)
+    rel_mdix = Relation(DIX_TO_MDIX, conn)
+    dix = rel_dix.sieve(motr, dix_all)
+    mdix = rel_mdix.sieve(dix, dix_all)
+
+    cas_all = Layer(CAS, conn)
+    rel_cas = Relation(DIX_TO_CAS, conn)
+    cas = rel_cas.sieve(dix, cas_all)
+    cas2 = rel_cas.sieve(mdix, cas_all)
+    cas.merge(cas2)
+
+    del dix_all
+    del cas_all
+    del mdix
+    del dix
+    del rel_dix
+    del rel_mdix
+    gc.collect()
+
+    rpc_all = Layer(CRPC, conn)
+    rel_ioo = Relation(IOO_TO_CRPC, conn)
+    rel_cob = Relation(COB_TO_CRPC, conn)
+    rel_cas = Relation(CAS_TO_CRPC, conn)
+    crpc_ioo = rel_ioo.sieve(ioo, rpc_all)
+    crpc_cob = rel_cob.sieve(cob, rpc_all)
+    crpc_cas = rel_cas.sieve(cas, rpc_all)
+
+    crpc = crpc_ioo
+    crpc.merge(crpc_cob)
+    crpc.merge(crpc_cas)
+
+    del rel_ioo
+    del rel_cob
+    del rel_cas
+    del crpc_ioo
+    del crpc_cob
+    del crpc_cas
+
+    handler.consume(crpc)
+
+    del rpc_all
+
+    rpc_all = Layer(SRPC, conn)
+    rel = XIDRelation(conn)
+    srpc = rel.sieve(crpc, rpc_all)
+    
+    del rpc_all
+    del crpc
+
+    handler.consume(srpc)
+
+    fom_all = Layer(FOM, conn)
+    rel = Relation(SRPC_TO_FOM, conn)
+    fom = rel.sieve(srpc, fom_all)
+    del rel
+    del srpc
+    del fom_all
+    gc.collect()
+
+    handler.consume(fom)
+
+    stio_all = Layer(STIO, conn)
+    rel = Relation(FOM_TO_STIO, conn)
+    stio = rel.sieve(fom, stio_all)
+
+    del stio_all
+    del rel
+    gc.collect()
+
+    handler.consume(stio)
+    del stio
+
+    # Only for writes
+    if fiter is S3PUT_FILTER:
+        betx_all = Layer(BETX, conn)
+        rel = Relation(FOM_TO_TX, conn)
+        betx = rel.sieve(fom, betx_all)
+
+        del betx_all
+        del fom
+        del rel
+        gc.collect()
+
+        handler.consume(betx)
+        del betx
+
+    handler.done()
+
+def parse_args():
+    parser = argparse.ArgumentParser(prog=sys.argv[0], description="""
+    rps.py: Generate request per second plots of Cortx S3 and Motr layers
+    """)
+
+    parser.add_argument("-d", "--db", type=str, default="m0play.db",
+                        help="Performance database (m0play.db)")
+    parser.add_argument("-g",'--s3get', action='store_true',
+                        help="Show histograms of S3GetObject operation")
+    parser.add_argument("-p", "--s3put", action='store_true',
+                        help="Show histograms of S3GetObject operation")
+    parser.add_argument("-s", "--save-only", action='store_true',
+                        help="Don't show figures, only save")
+    parser.add_argument("-w", "--avg-window", type=str, default='1s',
+                        help="Rolling window duration, default '1s'")
+
+    args = parser.parse_args()
+
+    return args
+
+def get_hosts_pids(conn):
+    table_descr_query = 'select * from sqlite_master where type="table" and name="host"'
+    table_descr_df = sql.read_sql(table_descr_query, con=conn.conn)
+
+    if table_descr_df.empty:
+        return None
+
+    pids_df = sql.read_sql('select * from host', con=conn.conn)
+
+    if pids_df.empty:
+        return None
+
+    pids_df = pids_df.drop_duplicates(subset=['pid'])
+    hostmap = pids_df.groupby('hostname')['pid'].apply(list).to_dict()
+    return hostmap
+
+def main():
+    args = parse_args()
+
+    pandas_init()
+
+    conn = Connection(args.db)
+    conn.connect()
+
+    if not args.s3get and not args.s3put:
+        args.s3get = True
+        args.s3put = True
+
+    hostmap = get_hosts_pids(conn)
+
+    if args.s3put:
+        handler = Handler(S3PUT_FILTER, args.avg_window,
+                          args.save_only, hostmap=hostmap)
+        calculate(conn, S3PUT_FILTER, handler)
+
+    if args.s3get:
+        handler = Handler(S3GET_FILTER, args.avg_window,
+                          args.save_only, hostmap=hostmap)
+        calculate(conn, S3GET_FILTER, handler)
+
+    return
+
+if __name__ == "__main__":
+    main()
+

--- a/performance/PerfLine/roles/perfline_setup/files/chronometry_v2/sys_utils.py
+++ b/performance/PerfLine/roles/perfline_setup/files/chronometry_v2/sys_utils.py
@@ -1,0 +1,502 @@
+#
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+import pandas as pd
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpl_patches
+from pandas.io import sql
+import sqlite3
+import gc
+import sys
+import argparse
+import re
+
+class Connection():
+    def __init__(self, filename):
+        self.filename = filename
+        self.conn = None
+
+    def connect(self):
+        self.conn = sqlite3.connect(self.filename)
+
+    def get(self):
+        if self.conn is None:
+            self.connect()
+        return self.conn
+
+class TypeId():
+    def __init__(self, name, type_id):
+        self.name = name
+        self.type_id = type_id
+        
+class Layer():
+    def __init__(self, layer_type, connection):
+        self.layer_type = layer_type
+        self.connection = connection
+        self.df = None
+
+    def write(self, df):
+        self.df = df
+
+    def read(self):
+        if self.df is None:
+            query = f'SELECT * FROM request where type_id="{self.layer_type.type_id}"'
+            df = sql.read_sql(query, con=self.connection.get())
+            self.df = df.loc[:,~df.columns.duplicated()]
+        return self.df
+
+    def merge(self, layer):
+        self.df = pd.concat([self.read(), layer.read()], ignore_index=True)
+
+    def pids(self):
+        return list(set(self.df['pid'].to_list()))
+
+class Filter():
+    def __init__(self, name, filter_cb=None):
+        self.name = name
+        self.filter_cb = filter_cb
+
+    def run(self, layer):
+        df = self.filter_cb(layer.read())
+        filtered_layer = Layer(layer.layer_type, layer.connection)
+        filtered_layer.write(df)
+        return filtered_layer
+
+def s3_filter(s3, request_state):
+    mask = s3[s3.state.str.contains(request_state)][['pid', 'id']].drop_duplicates()
+    return pd.merge(s3, mask, on=['pid', 'id'], how='inner')
+
+def s3putobject_filter(s3):
+    return s3_filter(s3, 'S3PutObjectAction')
+
+def s3getobject_filter(s3):
+    return s3_filter(s3, 'S3GetObjectAction')
+
+# List of supported Layers types:
+
+# [+] stio_req
+# [+] rpc_req
+# [-] fom_req_state
+# [+] fom_req
+# [-] rpc_post_reply
+# [+] be_tx
+# [+] dix_req
+# [+] cas_req
+# [+] client_req
+# [+] s3_request_state
+# [+] cob_req
+# [+] ioo_req
+
+S3       = TypeId('S3', 's3_request_state')
+MOTR_REQ = TypeId('MotrReq', 'client_req')
+COB      = TypeId('COB', 'cob_req')
+CAS      = TypeId('CAS', 'cas_req')
+DIX      = TypeId('DIX', 'dix_req')
+IOO      = TypeId('IOO', 'ioo_req')
+CRPC     = TypeId('CRPC', 'rpc_req')
+SRPC     = TypeId('SRPC', 'rpc_req')
+FOM      = TypeId('FOM', 'fom_req')
+STIO     = TypeId('STIO', 'stio_req')
+BETX     = TypeId('BETX', 'be_tx')
+
+S3PUT_FILTER = Filter('S3PutObject', s3putobject_filter)
+S3GET_FILTER = Filter('S3GetObject', s3getobject_filter)
+
+BINS = 50
+PERCENTILE = 0.95
+
+class Histogram():
+    BINS = 100
+    PERCENTILE = 0.95
+    MILLISECOND_SCALE = 10**6
+
+    def __init__(self, layer, start, stop, bins=BINS, percentile=PERCENTILE):
+        self.layer = layer
+        self.bins = bins
+        self.percentile = percentile
+        self.start_states = start
+        self.stop_states = stop
+        self.hist = None
+        self.name = f"{self.layer.layer_type.name}: {self.start_states} -> {self.stop_states}, ms"
+
+    def __process_states(self, df, states, inverse=False):
+        acc = pd.DataFrame()
+        for s in states:
+            tmp = df[(df.state == s)]
+            acc = pd.concat([acc, tmp], ignore_index=True)
+        if inverse:
+            acc['time'] = -acc['time']
+        acc.sort_values('time', inplace=True)
+        acc.drop_duplicates(subset=['pid', 'id', 'state'], keep='first', inplace=True)
+        return acc
+
+    def calculate(self):
+        df = self.layer.read()
+        if self.pids is not None:
+            df = df[(df.pid.isin(self.pids))]
+        start = self.__process_states(df, self.start_states, inverse=True)
+        stop = self.__process_states(df, self.stop_states)
+        df = pd.concat([start,stop], ignore_index=True)
+        gb = df.groupby(['pid','id']).agg({'time': [np.sum]})
+        gb.reset_index(inplace=True)
+        gb['delta'] = [x/self.MILLISECOND_SCALE for x in gb[('time', 'sum')]]
+        self.hist = gb['delta']
+        self.hist = self.hist[self.hist > 0]
+
+    def hist_df(self):
+        return self.hist
+
+    def draw(self, fig, ax, color):
+        df = self.hist
+        df[df > 0][df < df.quantile(self.percentile)].hist(bins=self.bins, alpha=0.5, figure=fig, ax=ax, color=color)
+
+        textstr = df.describe().to_string()
+        text = textstr.split('\n')
+        textstr = ''
+        for i in range(len(text)):
+            t = text[i].split(' ')
+            textstr = textstr + t[0] + ": " + t[-1]
+            if i < (len(text) - 1):
+                textstr = textstr + '\n'
+            
+        handles = [mpl_patches.Rectangle((0, 0), 1, 1, fc="white", ec="white", 
+                                         lw=0, alpha=0)]
+        labels = []
+        labels.append(textstr)
+        ax.legend(handles, labels, loc='upper right', prop={'size': 8}, 
+                  fancybox=True, framealpha=0.7, 
+                  handlelength=0, handletextpad=0)
+        
+
+    def name(self):
+        return self.name
+
+    def merge(self, histogram):
+        self.hist = pd.concat([self.hist, histogram.hist], ignore_index=True)
+        self.hist.reset_index(drop=True)
+
+
+class Relation():
+    def __init__(self, relation_type, connection):
+        self.relation_type = relation_type
+        self.connection = connection
+        self.df = None
+
+    def read(self):
+        if self.df is None:
+            query = f'SELECT * FROM relation where type_id="{self.relation_type.type_id}"'
+            df = sql.read_sql(query, con=self.connection.get())
+            self.df = df.loc[:,~df.columns.duplicated()]
+        return self.df
+
+    def sieve(self, upper_layer, next_layer):
+        upper_df = upper_layer.read()
+        next_df = next_layer.read()
+        rel_df = self.read()
+
+        mask_rel = upper_df[['pid', 'id']].drop_duplicates()
+        src_mask = pd.merge(rel_df, mask_rel, how='inner', left_on=['pid1', 'mid1'], right_on=['pid', 'id'])
+        src_mask.drop_duplicates(inplace=True)
+        result_df = pd.merge(next_df, src_mask[['pid2', 'mid2']], how='inner', left_on=['pid', 'id'], right_on=['pid2', 'mid2'])
+        result_df.drop_duplicates(inplace=True)
+        result_df.drop('pid2', 1, inplace=True)
+        result_df.drop('mid2', 1, inplace=True)
+
+        result = Layer(next_layer.layer_type, next_layer.connection)
+        result.write(result_df)
+
+        return result
+
+
+# List of available relations:
+#
+# [+] sxid_to_rpc
+# [+] rpc_to_sxid
+# [+] rpc_to_fom
+# [-] tx_to_gr
+# [+] fom_to_tx
+# [-] cas_fom_to_crow_fom
+# [+] fom_to_stio
+# [+] dix_to_mdix
+# [+] dix_to_cas
+# [+] cas_to_rpc
+# [+] client_to_dix
+# [+] s3_request_to_client
+# [+] client_to_cob
+# [+] cob_to_rpc
+# [+] client_to_ioo
+# [-] bulk_to_rpc
+# [+] ioo_to_rpc
+
+S3_TO_CLIENT  = TypeId('S3 to Motr client request', 's3_request_to_client')
+CLIENT_TO_DIX = TypeId('Motr client request to DIX request', 'client_to_dix')
+DIX_TO_MDIX   = TypeId('DIX request to MDIX request', 'dix_to_mdix')
+DIX_TO_CAS    = TypeId('DIX request to CAS request', 'dix_to_cas')
+CAS_TO_CRPC   = TypeId('CAS request to CPRC request', 'cas_to_rpc')
+CLIENT_TO_COB = TypeId('Motr client request to COB request', 'client_to_cob')
+COB_TO_CRPC   = TypeId('COB request to CPRC request', 'cob_to_rpc')
+CLIENT_TO_IOO = TypeId('Motr client request to IOO request', 'client_to_ioo')
+IOO_TO_CRPC   = TypeId('IOO request to CPRC request', 'ioo_to_rpc')
+RPC_TO_SXID   = TypeId('RPC request to Session & Transfer ID', 'rpc_to_sxid')
+SXID_TO_RPC   = TypeId('Session & Transfer ID to RPC request', 'sxid_to_rpc')
+SRPC_TO_FOM   = TypeId('SRPC request to FOM', 'rpc_to_fom')
+FOM_TO_STIO   = TypeId('FOM to STOB IO request', 'fom_to_stio')
+FOM_TO_TX     = TypeId('FOM to BE TX request', 'fom_to_tx')
+
+
+class XIDRelation():
+    def __init__(self,  connection):
+        self.connection = connection
+        self.rpc_to_sxid = Relation(RPC_TO_SXID, connection)
+        self.sxid_to_rpc = Relation(SXID_TO_RPC, connection)
+        self.df = None
+
+    def read(self):
+        if self.df is None:
+            df1 = self.rpc_to_sxid.read()
+            df2 = self.sxid_to_rpc.read()
+            self.df = pd.concat([df1, df2], ignore_index=True)
+        return self.df
+
+    def sieve(self, upper_layer, next_layer):
+        crpc = upper_layer.read()
+        rpc = next_layer.read()
+        relations = self.read()
+
+        crpc_mask = crpc[['pid', 'id']].drop_duplicates()
+        sxids = pd.merge(crpc_mask, relations, how='inner', left_on=['pid', 'id'], right_on=['pid1', 'mid1'])
+        sxids = sxids[['pid2', 'mid2']].drop_duplicates()
+        sxids.rename(columns={'pid2': 'pid', 'mid2': 'id'}, inplace=True)
+        srpc_mask = pd.merge(sxids, relations, how='inner', left_on=['pid', 'id'], right_on=['pid1', 'mid1'])
+        srpc_mask = srpc_mask[['pid2', 'mid2']].drop_duplicates()
+        srpc = pd.merge(rpc, srpc_mask, how='inner', left_on=['pid', 'id'], right_on=['pid2', 'mid2'])
+        srpc.drop_duplicates(inplace=True)
+        srpc.drop('pid2', 1, inplace=True)
+        srpc.drop('mid2', 1, inplace=True)
+
+        result = Layer(next_layer.layer_type, next_layer.connection)
+        result.write(srpc)
+
+        return result
+
+class Plot():
+    def __init__(self, hist, ax):
+        self.hist = hist
+        self.ax = ax
+
+    def name():
+        return self.hist.name
+
+class Figure():
+    COLORS = ['g', 'b', 'r', 'c', 'm']
+    color_idx = 0
+    figure_idx = 0
+
+    @staticmethod
+    def next_figure():
+        Figure.figure_idx = Figure.figure_idx + 1
+        return Figure.figure_idx
+
+    def next_color(self):
+        color = Figure.COLORS[self.color_idx]
+        self.color_idx = (self.color_idx + 1) % len(Figure.COLORS)
+        return color
+
+    def __init__(self, name, rows, cols):
+        self.mpl_idx = Figure.next_figure()
+        self.fig = plt.figure(self.mpl_idx, figsize=(20, 10))
+        self.mpl_plt = plt
+        self.layout = self.fig.add_gridspec(rows, cols)
+        self.rows = rows
+        self.cols = cols
+        self.name = name
+        filename = name.replace(' ', '_')
+        filename = filename.replace('-', '_')
+        filename = filename + ".png"
+        self.filename = filename
+        self.plots = []
+        self.axes = dict()
+        self.mpl_plt.suptitle(self.name)
+    
+    def add(self, hist, row, col, sharex=None, sharey=None):
+        if (row, col) in self.axes:
+            ax = self.axes[(row, col)]
+        else:
+            ax = self.fig.add_subplot(self.layout[row, col], sharex=sharex, sharey=sharey)
+            self.axes[(row, col)] = ax
+        self.plots.append(Plot(hist, ax))
+        return ax
+
+    def draw(self):
+        for plot in self.plots:
+            plot.hist.draw(self.fig, plot.ax, self.next_color())
+            if plot.hist.name:
+                plot.ax.set_title(plot.hist.name)
+
+    def show(self):
+        self.mpl_plt.figure(self.mpl_idx)
+        self.mpl_plt.subplots_adjust(left=0.04,
+                                     bottom=0.06,
+                                     right=0.99,
+                                     top=0.92,
+                                     wspace=0.11,
+                                     hspace=0.11)
+        self.mpl_plt.show()
+
+    def save(self):
+        self.mpl_plt.figure(self.mpl_idx)
+        self.mpl_plt.subplots_adjust(left=0.04,
+                                     bottom=0.06,
+                                     right=0.99,
+                                     top=0.92,
+                                     wspace=0.11,
+                                     hspace=0.11)
+        self.fig.savefig(self.filename, format="png")
+
+class Queue():
+    def __init__(self, layer, start, stop, pids=None):
+        self.layer = layer
+        self.start_states = start
+        self.stop_states = stop
+        self.queue = pd.DataFrame()
+        self.rps_in = pd.DataFrame()
+        self.rps_out = pd.DataFrame()
+        self.name = f"{self.layer.layer_type.name}: {self.start_states} -> {self.stop_states}, ms"
+        self.name = None
+        self.label = ''
+        self.pids = pids
+
+    def __df_prepare(self, df, states, val, rule='first'):
+        df = df[(df.state.isin(states))]
+        df.drop_duplicates(subset=['pid', 'id', 'state'],
+                           keep=rule, inplace=True)
+        df = df[['time','state']]
+        df.set_index('time', inplace=True)
+        df['state'] = val
+        df = df.sort_values('time')
+        df.index = [pd.Timestamp(x, unit='ns') for x in df.index]
+        return df
+
+    def __filter_queue(self, df):
+        up = df[(df.state.isin(self.start_states))]
+        down = df[(df.state.isin(self.stop_states))]
+
+        up_mask = up[['pid', 'id']].drop_duplicates()
+        down_mask = down[['pid', 'id']].drop_duplicates()
+        mask = pd.merge(up_mask, down_mask, how='inner', on=['pid','id'])
+        mask = mask[['pid', 'id']].drop_duplicates()
+
+        df = pd.merge(df, mask, how='inner', on=['pid','id'])
+        return df
+    
+    def calculate(self):
+        df = self.layer.read()
+        if self.pids is not None:
+            df = df[(df.pid.isin(self.pids))]
+        df = self.__filter_queue(df)
+        df_in = self.__df_prepare(df, self.start_states, 1)
+        df_out = self.__df_prepare(df, self.stop_states, -1, rule='last')
+        df = pd.concat([df_in, df_out])
+        df = df.sort_index().cumsum()
+        nl = '\n'
+        self.label = f'{self.layer.layer_type.name}{nl}{self.start_states} -> {self.stop_states}'
+        df.rename(columns={"state": self.label}, inplace=True)
+        self.queue = df
+                
+    def draw(self, fig, ax, color):
+        df = self.queue
+        if df.empty:
+            return
+        ax = df.plot(alpha=0.5, figure=fig, ax=ax, color=color, grid=True)
+        ax.legend(loc="upper right")
+        ymax = df[self.label].max()
+        ax.set_ylim([0, ymax * 2] )
+
+    def name(self):
+        return self.name
+
+class RPS():
+    def __init__(self, layer, states, avg_window='1s',
+                 color=None, rule='first', pids=None):
+        self.layer = layer
+        self.states = states
+        self.rps = pd.DataFrame()
+        self.window = avg_window
+        self.color = color
+        self.name = None
+        self.label = ''
+        self.keep_rule = rule
+        self.pids = pids
+
+    def __calc_rps(self, df):
+        # Average window field is variable, and scale must be normilized, so
+        # resulting rolling sum shows results as requests per second.
+        # Using the formula:
+        # 1 RPS = N * avg_window,
+        # where N is the scale coefficient
+        # avg_window is an averaging window and it has dimension
+        # of 1 Request per [avg_window]
+        # If window is 1 second, then rolling sum shows the number
+        # of requests per 1 second, and N = 1.
+        # If window is 100 ms, it shows the number of requests per 100ms,
+        # or 0.1 seconds, and N = 10.
+        UNITS = {'s': 1, 'ms': 1000, 'us': 1000000, 'ns': 1000000000}
+        r = re.split('(\d+)', self.window)
+        unit = r[2]
+        scale = int(r[1])
+        N = UNITS[unit] / scale
+        df['state'] = N
+        df = df.rolling(self.window).sum()
+        return df
+
+    def __df_prepare(self, df, states, val, rule='first'):
+        df = df[(df.state.isin(states))]
+        df.drop_duplicates(subset=['pid', 'id', 'state'], keep=rule, inplace=True)
+        df = df[['time','state']]
+        df.set_index('time', inplace=True)
+        df['state'] = val
+        df = df.sort_values('time')
+        df.index = [pd.Timestamp(x, unit='ns') for x in df.index]
+        return df
+    
+    def calculate(self):
+        df = self.layer.read()
+        if self.pids is not None:
+            df = df[(df.pid.isin(self.pids))]
+
+        df = self.__df_prepare(df, self.states, 1, self.keep_rule)
+        rps = self.__calc_rps(df)
+        self.label = f"{self.layer.layer_type.name}: {self.states}"
+        rps.rename(columns={"state": self.label}, inplace=True)
+        self.rps = rps
+                
+    def draw(self, fig, ax, color):
+        if self.color:
+            color = self.color
+        if self.rps.empty:
+            return
+        ax = self.rps.plot(alpha=0.5, figure=fig, ax=ax, color=color, grid=True)
+        ax.legend(loc="upper right")
+        ymax = self.rps[self.label].max()
+        ax.set_ylim([0, ymax * 2] )
+
+    def name(self):
+        return self.name

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/process_addb_data.sh
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/process_addb_data.sh
@@ -30,6 +30,7 @@ function main()
     parse_params "$@"
     check_params
     generate_queue_imgs
+    generate_rps_imgs
     generate_histogram_imgs
     generate_timeline_imgs
 }
@@ -53,6 +54,13 @@ function generate_queue_imgs()
     $TOOLS_DIR/queues.py --db $M0PLAY_DB --no-window --output-file queues_aggr || true
     $TOOLS_DIR/queues.py --db $M0PLAY_DB --no-window -s --output-file queues_srv || true
     $TOOLS_DIR/queues.py --db $M0PLAY_DB --no-window -c --output-file queues_cli || true
+}
+
+function generate_rps_imgs()
+{
+    echo "generating RPS..."
+    python3 $TOOLS_DIR/rps.py --db $M0PLAY_DB -w 10ms --s3put --save-only || true
+    python3 $TOOLS_DIR/rps.py --db $M0PLAY_DB -w 10ms --s3get --save-only || true
 }
 
 function generate_histogram_imgs()

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/stat/report_generator/gen_report.py
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/stat/report_generator/gen_report.py
@@ -323,12 +323,14 @@ def parse_addb_timelines(addb_stat_dir):
 def parse_addb_info(addb_stat_dir):
     if isdir(addb_stat_dir):
         queues_imgs = [f for f in listdir(addb_stat_dir) if f.startswith('queues_')]
-        hist_imgs = [f for f in listdir(addb_stat_dir) if '_histograms' in f]
+        hist_imgs = [f for f in listdir(addb_stat_dir) if '_histogram' in f]
+        rps_imgs = [f for f in listdir(addb_stat_dir) if '_cluster_wide_RPS' in f]
     else:
         queues_imgs = []
         hist_imgs = []
+        rps_imgs = []
 
-    return queues_imgs, hist_imgs
+    return queues_imgs, hist_imgs, rps_imgs
 
 def detect_iostat_imgs(nodes_stat_dirs):
     iostat_img_types = set()
@@ -418,7 +420,7 @@ def main():
     dstat_net_info = parse_dstat_info(nodes_stat_dirs)
 
     # Images for addb queues
-    addb_queues, addb_hists = parse_addb_info(addb_stat_dir)
+    addb_queues, addb_hists, addb_rps = parse_addb_info(addb_stat_dir)
     timelines_imgs = parse_addb_timelines(addb_stat_dir)
 
     with open(join(report_gen_dir, 'templates/home.html'), 'r') as home:
@@ -458,6 +460,7 @@ def main():
             blktrace_imgs=blktrace_imgs,
             addb_queues=addb_queues,
             addb_hists=addb_hists,
+            addb_rps=addb_rps,
             timelines_imgs=timelines_imgs,
             task_id=task_id
         ))

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/stat/report_generator/templates/addb.html
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/stat/report_generator/templates/addb.html
@@ -8,6 +8,16 @@
     
 </div>
 {% endif %}
+{% if addb_rps %}
+<h2 align=center>ADDB Cortx RPS</h2>
+<div class="row">
+    
+    {% for img in addb_rps %}
+        <img src="/report/{{task_id}}/addb_imgs/{{img}}" alt="ADDB RPS">
+    {% endfor %}
+    
+</div>
+{% endif %}
 {% if addb_hists %}
 <h2 align=center>ADDB Cortx histograms</h2>
 <div class="row">


### PR DESCRIPTION
This patch introduces Request per second metric for ADDB chronometry tools.
It allows to visualize incoming ang outgoing request flow intensity and
is commonly used for performance analysis.

Signed-off-by: Maxim Malezhin <maxim.malezhin@seagate.com>