### PR TITLE
EOS-20006:[PerfPro] Enable multiple runs of benchmarks depending on user input

### DIFF
--- a/performance/PerfPro/PerfProBenchmark/cosbench/cosbench_DBupdate.py
+++ b/performance/PerfPro/PerfProBenchmark/cosbench/cosbench_DBupdate.py
@@ -19,7 +19,7 @@ import urllib.request
 
 Main_path = sys.argv[2]
 Config_path = sys.argv[3]
-
+iteration = sys.argv[4]
 
 def makeconfig(name):  # function for connecting with configuration file
     with open(name) as config_file:
@@ -35,7 +35,7 @@ nodes_list=configs_config.get('NODES')
 clients_list=configs_config.get('CLIENTS')
 pc_full=configs_config.get('PC_FULL')
 overwrite=configs_config.get('OVERWRITE')
-iteration=configs_config.get('ITERATION')
+#iteration=configs_config.get('ITERATION')
 
 nodes_num=len(nodes_list)
 clients_num=len(clients_list)

--- a/performance/PerfPro/PerfProBenchmark/hsbench/hsbench_DBupdate.py
+++ b/performance/PerfPro/PerfProBenchmark/hsbench/hsbench_DBupdate.py
@@ -19,6 +19,7 @@ import urllib.request
 # Path for yaml files locations
 Main_path = sys.argv[2]  # database url
 Config_path = sys.argv[3]
+iteration = sys.argv[4]
 
 # Function for connecting with configuration file
 def makeconfig(name):  
@@ -34,7 +35,7 @@ nodes_list=configs_config.get('NODES')
 clients_list=configs_config.get('CLIENTS')
 pc_full=configs_config.get('PC_FULL')
 overwrite=configs_config.get('OVERWRITE')
-iteration=configs_config.get('ITERATION')
+#iteration=configs_config.get('ITERATION')
 
 
 nodes_num=len(nodes_list)

--- a/performance/PerfPro/PerfProBenchmark/hsbench/run_benchmark.sh
+++ b/performance/PerfPro/PerfProBenchmark/hsbench/run_benchmark.sh
@@ -21,7 +21,7 @@ TIMESTAMP=`date +'%Y-%m-%d_%H:%M:%S'`
 MAIN="/root/PerfProBenchmark/main.yml"
 CONFIG="/root/PerfProBenchmark/config.yml"
 LOG_COLLECT="/root/PerfProBenchmark/collect_logs.py"
-
+ITERATION=$(yq -r .ITERATION $CONFIG)
 
 validate_args() {
 
@@ -116,18 +116,20 @@ validate_args
 #
 ./installHSbench.sh
 #
-
-if [ ! -d $BENCHMARKLOG ]; then
-      mkdir $BENCHMARKLOG
-      hotsause_benchmark 2>&1 | tee benchmark.log/output.log 
-      python3 hsbench_DBupdate.py $BENCHMARKLOG $MAIN $CONFIG
-      python3 $LOG_COLLECT $CONFIG
+for ((ITR=1;ITR<=ITERATION;ITR++))
+do
+    if [ ! -d $BENCHMARKLOG ]; then
+          mkdir $BENCHMARKLOG
+          hotsause_benchmark 2>&1 | tee benchmark.log/output.log 
+          python3 hsbench_DBupdate.py $BENCHMARKLOG $MAIN $CONFIG $ITR
+          python3 $LOG_COLLECT $CONFIG
       
-else
-      mv $BENCHMARKLOG $CURRENTPATH/benchmark.bak_$TIMESTAMP
-      mkdir $BENCHMARKLOG
-      hotsause_benchmark 2>&1 | tee benchmark.log/output.log 
-      python3 hsbench_DBupdate.py $BENCHMARKLOG $MAIN $CONFIG
-      python3 $LOG_COLLECT $CONFIG
+    else
+          mv $BENCHMARKLOG $CURRENTPATH/benchmark.bak_$TIMESTAMP
+          mkdir $BENCHMARKLOG
+          hotsause_benchmark 2>&1 | tee benchmark.log/output.log 
+          python3 hsbench_DBupdate.py $BENCHMARKLOG $MAIN $CONFIG $ITR
+          python3 $LOG_COLLECT $CONFIG
 
-fi
+    fi
+done

--- a/performance/PerfPro/PerfProBenchmark/s3bench_meta/run_s3benchmark.sh
+++ b/performance/PerfPro/PerfProBenchmark/s3bench_meta/run_s3benchmark.sh
@@ -13,7 +13,7 @@ IO_SIZE=""
 MAIN="/root/PerfProBenchmark/main.yml"
 CONFIG="/root/PerfProBenchmark/config.yml"
 LOG_COLLECT="/root/PerfProBenchmark/collect_logs.py"
-
+ITERATION=$(yq -r .ITERATION $CONFIG)
 
 validate_args() {
 
@@ -109,18 +109,20 @@ validate_args
 #
 ./installS3bench.sh
 #
+for ((ITR=1;ITR<=ITERATION;ITR++))
+do
+    if [ ! -d $BENCHMARKLOG ]; then
+          mkdir $BENCHMARKLOG
+          s3benchmark
+          python3 s3bench_DBupdate.py $BENCHMARKLOG $MAIN $CONFIG $ITR
+          python3 $LOG_COLLECT $CONFIG
 
-if [ ! -d $BENCHMARKLOG ]; then
-      mkdir $BENCHMARKLOG
-      s3benchmark
-      python3 s3bench_DBupdate.py $BENCHMARKLOG $MAIN $CONFIG
-      python3 $LOG_COLLECT $CONFIG
+    else
+          mv $BENCHMARKLOG $CURRENTPATH/benchmark.bak_$TIMESTAMP
+          mkdir $BENCHMARKLOG
+          s3benchmark
+          python3 s3bench_DBupdate.py $BENCHMARKLOG $MAIN $CONFIG $ITR      
+          python3 $LOG_COLLECT $CONFIG
 
-else
-      mv $BENCHMARKLOG $CURRENTPATH/benchmark.bak_$TIMESTAMP
-      mkdir $BENCHMARKLOG
-      s3benchmark
-      python3 s3bench_DBupdate.py $BENCHMARKLOG $MAIN $CONFIG      
-      python3 $LOG_COLLECT $CONFIG
-
-fi
+    fi
+done

--- a/performance/PerfPro/PerfProBenchmark/s3bench_meta/s3bench_DBupdate.py
+++ b/performance/PerfPro/PerfProBenchmark/s3bench_meta/s3bench_DBupdate.py
@@ -20,7 +20,7 @@ import urllib.request
 #Config_path = '/root/Modified/config.yml'
 Main_path = sys.argv[2]
 Config_path = sys.argv[3]
-
+iteration = sys.argv[4]
 
 def makeconfig(name):  #function for connecting with configuration file
     with open(name) as config_file:
@@ -35,7 +35,7 @@ nodes_list=configs_config.get('NODES')
 clients_list=configs_config.get('CLIENTS')
 pc_full=configs_config.get('PC_FULL')
 overwrite=configs_config.get('OVERWRITE')
-iteration=configs_config.get('ITERATION')
+#iteration=configs_config.get('ITERATION')
 
 nodes_num=len(nodes_list)
 clients_num=len(clients_list)

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/tasks/cosbench.yml
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/tasks/cosbench.yml
@@ -1,7 +1,7 @@
 ---
  - name: "[Cosbench]: Cosbench running with clients=300 bucket=1"
    shell: cd /root/PerfProBenchmark/cosbench; ./s3cosbench_benchmark.sh -nc "300" -ns {{ item.numsamples }} -s {{ item.objsize }} -b 1 -w mixed -t 600
-   delegate_to: "client-1"
+   delegate_to: "clientnode-1"
    loop:
        - { objsize: '4Kb', numsamples: '33000'}
        - { objsize: '100Kb', numsamples: '130000'}
@@ -16,7 +16,7 @@
 
  - name: "[Cosbench]: Cosbench running with clients=300 bucket=10"
    shell: cd /root/PerfProBenchmark/cosbench; ./s3cosbench_benchmark.sh -nc "300" -ns {{ item.numsamples }} -s {{ item.objsize }} -b 10 -w mixed -t 600
-   delegate_to: "client-1"
+   delegate_to: "clientnode-1"
    loop:
        - { objsize: '4Kb', numsamples: '3300'}
        - { objsize: '100Kb', numsamples: '13000'}
@@ -31,7 +31,7 @@
 
  - name: "[Cosbench]: Cosbench running with clients=300 bucket=50"
    shell: cd /root/PerfProBenchmark/cosbench; ./s3cosbench_benchmark.sh -nc "300" -ns {{ item.numsamples }} -s {{ item.objsize }} -b 50 -w mixed -t 600
-   delegate_to: "client-1"
+   delegate_to: "clientnode-1"
    loop:
        - { objsize: '4Kb', numsamples: '660'}
        - { objsize: '100Kb', numsamples: '2600'}

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/tasks/hsbench.yml
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/tasks/hsbench.yml
@@ -1,7 +1,7 @@
 ---
  - name: "[HSbench-1-Bucket]: HSbench running for 1 Bucket"
    shell: cd /root/PerfProBenchmark/hsbench; ./run_benchmark.sh -b 1 -o {{ item.numsamples }} -s {{ item.objsize }} -t 300 -d 600
-   delegate_to: "client-1"
+   delegate_to: "clientnode-1"
    loop:
        - { objsize: '4Kb', numsamples: '33000'}
        - { objsize: '100Kb', numsamples: '130000'}
@@ -16,7 +16,7 @@
 
  - name: "[HSbench-10-Buckets]: HSbench running for 10 Buckets"
    shell: cd /root/PerfProBenchmark/hsbench; ./run_benchmark.sh -b 10 -o {{ item.numsamples }} -s {{ item.objsize }} -t 300 -d 600
-   delegate_to: "client-1"
+   delegate_to: "clientnode-1"
    loop:
        - { objsize: '4Kb', numsamples: '33000'}
        - { objsize: '100Kb', numsamples: '130000'}
@@ -31,7 +31,7 @@
 
  - name: "[HSbench-50-Buckets]: HSbench running for 50 Buckets"
    shell: cd /root/PerfProBenchmark/hsbench; ./run_benchmark.sh -b 50 -o {{ item.numsamples }} -s {{ item.objsize }} -t 300 -d 600
-   delegate_to: "client-1"
+   delegate_to: "clientnode-1"
    loop:
        - { objsize: '4Kb', numsamples: '33000'}
        - { objsize: '100Kb', numsamples: '130000'}

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/tasks/main.yml
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/tasks/main.yml
@@ -40,6 +40,7 @@
        - pymongo==3.11.0
        - pandas==1.0.5
        - datetime==4.3
+       - yq
      executable: pip3
    delegate_to: "{{ item }}"
    with_items: "{{ groups['all'] }}"

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/tasks/s3bench.yml
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/tasks/s3bench.yml
@@ -1,7 +1,7 @@
 ---
  - name: "[S3bench-small-objects]: S3benchmark running ( size='4Kb,100Kb,256Kb' clients=300)"
    shell: cd /root/PerfProBenchmark/s3bench_meta; ./run_s3benchmark.sh -nc 300 -ns {{ item.numsamples }} -s {{ item.objsize }}
-   delegate_to: "client-1"
+   delegate_to: "clientnode-1"
    loop:
        - { objsize: '4Kb', numsamples: '33000'}
        - { objsize: '100Kb', numsamples: '130000'}
@@ -9,7 +9,7 @@
 
  - name: "[S3bench-medium-objects]: S3benchmark running ( size='1Mb,5Mb,16Mb' clients=300)"
    shell: cd /root/PerfProBenchmark/s3bench_meta; ./run_s3benchmark.sh -nc 300 -ns {{ item.numsamples }} -s {{ item.objsize }}
-   delegate_to: "client-1"
+   delegate_to: "clientnode-1"
    loop:
        - { objsize: '1Mb', numsamples: '150000'}
        - { objsize: '5Mb', numsamples: '82000'}
@@ -17,7 +17,7 @@
 
  - name: "[S3bench-large-objects]: S3benchmark running ( size='36Mb,64Mb,128Mb,256Mb' clients=300)"
    shell: cd /root/PerfProBenchmark/s3bench_meta; ./run_s3benchmark.sh -nc 300 -ns {{ item.numsamples }} -s {{ item.objsize }}
-   delegate_to: "client-1"
+   delegate_to: "clientnode-1"
    loop:
        - { objsize: '36Mb', numsamples: '24000'}
        - { objsize: '64Mb', numsamples: '15000'}


### PR DESCRIPTION
Note:
changed "client-1" to "clientnode-1" to all .yml config files

1) Updated main.yml for 'yq' package as prerequisite

2) Update respective run file for all tools.

3) "for loop" for iteration for each tool  (.sh run  file) 

4) db.py file update for iteration argument 

  a ) iteration = sys.argv[4]
