### PR TITLE
EOS-20807 : adding missed 1Kb s3bench config for metadata ops

### DIFF
--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/s3bench_meta/run_s3benchmark.sh
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/s3bench_meta/run_s3benchmark.sh
@@ -61,9 +61,9 @@ do
 
             mkdir $MKDIR
             if [ $SIZE_OF_OBJECTS = "1Kb" ]; then         
-                  echo "$BINPATH/s3bench_meta -accessKey=$ACCESS_KEY  -accessSecret=$SECRET_KEY -bucket=$bucket -endpoint=$ENDPOINTS -numClients=$NUMCLIENTS -numSamples=$NO_OF_SAMPLES -objectNamePrefix=loadgen -objectSize=$SIZE_OF_OBJECTS -headObj -putObjTag -getObjTag -verbose -sampleReads=12 > $MKDIR/s3bench_Numclients_$NUMCLIENTS\_NS_$NO_OF_SAMPLES\_size_$SIZE_OF_OBJECTS\.log" 
+                  echo "$BINPATH/s3bench_meta -accessKey=$ACCESS_KEY  -accessSecret=$SECRET_KEY -bucket=$bucket -endpoint=$ENDPOINTS -numClients=$NUMCLIENTS -numSamples=$NO_OF_SAMPLES -objectNamePrefix=loadgen -objectSize=$SIZE_OF_OBJECTS -headObj -putObjTag -getObjTag -verbose -sampleReads=2 > $MKDIR/s3bench_Numclients_$NUMCLIENTS\_NS_$NO_OF_SAMPLES\_size_$SIZE_OF_OBJECTS\.log" 
 
-                  $BINPATH/s3bench_meta -accessKey=$ACCESS_KEY  -accessSecret=$SECRET_KEY -bucket=$bucket -endpoint=$ENDPOINTS -numClients=$NUMCLIENTS -numSamples=$NO_OF_SAMPLES -objectNamePrefix=loadgen -objectSize=$SIZE_OF_OBJECTS -headObj -putObjTag -getObjTag -verbose -sampleReads=12 > $MKDIR/s3bench_Numclients_$NUMCLIENTS\_NS_$NO_OF_SAMPLES\_size_$SIZE_OF_OBJECTS\.log 
+                  $BINPATH/s3bench_meta -accessKey=$ACCESS_KEY  -accessSecret=$SECRET_KEY -bucket=$bucket -endpoint=$ENDPOINTS -numClients=$NUMCLIENTS -numSamples=$NO_OF_SAMPLES -objectNamePrefix=loadgen -objectSize=$SIZE_OF_OBJECTS -headObj -putObjTag -getObjTag -verbose -sampleReads=2 > $MKDIR/s3bench_Numclients_$NUMCLIENTS\_NS_$NO_OF_SAMPLES\_size_$SIZE_OF_OBJECTS\.log 
             else
                echo "$BINPATH/s3bench_meta -accessKey=$ACCESS_KEY  -accessSecret=$SECRET_KEY -bucket=$bucket -endpoint=$ENDPOINTS -numClients=$NUMCLIENTS -numSamples=$NO_OF_SAMPLES -objectNamePrefix=loadgen -objectSize=$SIZE_OF_OBJECTS -verbose > $MKDIR/s3bench_Numclients_$NUMCLIENTS\_NS_$NO_OF_SAMPLES\_size_$SIZE_OF_OBJECTS\.log"
 

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/tasks/s3bench.yml
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/tasks/s3bench.yml
@@ -3,6 +3,7 @@
    shell: cd /root/PerfProBenchmark/s3bench_meta; ./run_s3benchmark.sh -nc 300 -ns {{ item.numsamples }} -s {{ item.objsize }}
    delegate_to: "clientnode-1"
    loop:
+       - { objsize: '1Kb', numsamples: '4000'}
        - { objsize: '4Kb', numsamples: '33000'}
        - { objsize: '100Kb', numsamples: '130000'}
        - { objsize: '256Kb', numsamples: '96000'}


### PR DESCRIPTION
Added back missed 1Kb config for s3bench which is required to get Metadata stats like PutObjectTag, GetObjectTag and HeadObject.

Signed-off-by: Rajesh Deshmukh <rajesh.deshmukh@seagate.com>