### PR TITLE
EOS-17808 : Implemented Support for collecting only system stats

### DIFF
--- a/performance/AutoPerf/README.md
+++ b/performance/AutoPerf/README.md
@@ -6,3 +6,8 @@
 
 ## Example to run AutoPerf: 
 $ ansible-playbook -i hosts deploy_autoperf.yml --extra-vars '{ "BENCHMARK":"s3bench_basic", "CONFIGURATION":"short", "SAMPLE":"5", "SKIPCLEANUP":"no", "KEY":"password", "nodes":{"1": "node1.loc.seagate.com", "2": "node2.loc.seagate.com"} , "clients":{"1": "client1.loc.seagate.com"}}' -v
+
+## Example to collect only system stats(without any benchmark): 
+$  ansible-playbook -i hosts deploy_autoperf.yml --extra-vars '{ "BENCHMARK":"NONE", "WAIT":"5" ,"CONFIGURATION":"short", "SAMPLE":"5", "SKIPCLEANUP":"no", "KEY":"password", "nodes":{"1": "node1.loc.seagate.com", "2": "node2.loc.seagate.com"} , "clients":{"1": "client1.loc.seagate.com"}}' -v
+
+

--- a/performance/AutoPerf/roles/autoPerf/tasks/main.yml
+++ b/performance/AutoPerf/roles/autoPerf/tasks/main.yml
@@ -109,27 +109,32 @@
 
  - name: s3benchmark Running
    shell: cd /root/cortx-benchmark/s3bench_basic; ./run_s3benchmark.sh -nc {{ CLIENTS }} -ns {{ NUMSAMPLES}} -s {{ IOSIZE }} -sm {{ SAMPLE }} -cl {{ SKIPCLEANUP }}
-   when: BENCHMARK == "s3bench_basic"
+   when: BENCHMARK == "s3bench_basic" 
    delegate_to: "{{ item }}"
    with_items: "{{ groups['clients'] }}"
 
  - name: HSbenchmark Running
    shell: cd /root/cortx-benchmark/hsbench; ./run_benchmark.sh -b {{ BUCKETS }} -o {{ NUMSAMPLES }} -s {{ IOSIZE }} -t {{ CLIENTS }} -d {{ DURATION }} -sm {{ SAMPLE }}
-   when: BENCHMARK == "hsbench"
+   when: BENCHMARK == "hsbench" 
    delegate_to: "{{ item }}"
    with_items: "{{ groups['clients'] }}"
 
  - name: Cosbench Running
    shell: cd /root/cortx-benchmark/cosbench; ./s3cosbench_benchmark.sh -nc {{ CLIENTS }} -ns {{ NUMSAMPLES }} -s {{ IOSIZE }} -b {{ BUCKETS }} -w {{ OPERATION }} -t {{ DURATION }} -sm {{ SAMPLE }}
-   when: BENCHMARK == "cosbench"
+   when: BENCHMARK == "cosbench" 
    delegate_to: "{{ item }}"
    with_items: "{{ groups['clients'] }}"
 
  - name: Fio Running
    shell: cd /root/cortx-benchmark/fio; ./run_fio.sh {{ nodes['1'] }} {{ DURATION }} {{ IOSIZE }} {{ NUMJOBS }} {{ SAMPLE }} {{ TEMPLATE }}
-   when: BENCHMARK == "fio"
+   when: BENCHMARK == "fio" 
    delegate_to: "{{ item }}"
    with_items: "{{ groups['clients'] }}"
+
+ - name: Running and monitoring system stats
+   pause:
+    minutes: "{{ WAIT }}"
+   when: BENCHMARK == "NONE"
 
  - name: Telegraf monitoring stop
    service:


### PR DESCRIPTION
Signed-off-by: Rahul Ranjan <rahul.ranjan@seagate.com>

Implemented Support for collecting only system stats

for collecting system stats using AutoPerf 
1. "BENCHMARK" needs to be set "NONE"
2.  "WAIT" variable value will be considered in "minutes" 

-----
[View rendered performance/AutoPerf/README.md](https://github.com/rahulr-seagate/seagate-tools/blob/main/performance/AutoPerf/README.md)