### PR TITLE
EOS-20989 : Implemented fix for Object sizes having different formats

### DIFF
--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/cosbench/cosbench_DBupdate.py
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/cosbench/cosbench_DBupdate.py
@@ -85,8 +85,31 @@ def insert_data(file,Build,Version,Config_ID,db,col,Branch,OS):  # function for 
                     buckets= int(re.split(" ", attr[2])[1])
                     objects= int(re.split(" ", attr[3])[1])
                     sessions= int(re.split(" ", attr[4])[1])
-                    entry = {"Name": "Cosbench", "Operation": operation, "Build": Build, "Version": Version,"Branch": Branch ,"OS": OS, "Count_of_Servers": nodes_num , "Count_of_Clients": clients_num , "Object_Size": obj_size, "Buckets": buckets, "Objects": objects, "Sessions": sessions , 'PKey' : Version[0]+'_'+Branch[0].upper()+'_'+Build+'_ITR'+str(iteration)+'_'+str(nodes_num)+'N_'+str(clients_num)+'C_'+str(pc_full)+'PC_'+str(custom).upper()+'_COS_'+str(obj_size.replace(" ",""))+'_'+str(buckets)+'_'+operation[0].upper()+'_'+str(sessions) }
-                    update_data = {"Log_File": filename, "Operation": row[1], "IOPS": iops, "Throughput": throughput, "Latency": lat, "HOST": socket.gethostname(), "Config_ID": Config_ID, "Timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+                    entry = {
+                        "Name": "Cosbench", 
+                        "Operation": operation, 
+                        "Build": Build, 
+                        "Version": Version,
+                        "Branch": Branch ,
+                        "OS": OS, 
+                        "Count_of_Servers": nodes_num ,
+                        "Count_of_Clients": clients_num , 
+                        "Object_Size": str(obj_size.replace(" ","").upper()), 
+                        "Buckets": buckets,
+                        "Objects": objects, 
+                        "Sessions": sessions , 
+                        'PKey' : Version[0]+'_'+Branch[0].upper()+'_'+Build+'_ITR'+str(iteration)+'_'+str(nodes_num)+'N_'+str(clients_num)+'C_'+str(pc_full)+'PC_'+str(custom).upper()+'_COS_'+str(obj_size.replace(" ","").upper())+'_'+str(buckets)+'_'+operation[0].upper()+'_'+str(sessions) 
+                        }
+                    update_data = {
+                        "Log_File": filename, 
+                        "Operation": row[1], 
+                        "IOPS": iops, 
+                        "Throughput": throughput, 
+                        "Latency": lat, 
+                        "HOST": socket.gethostname(), 
+                        "Config_ID": Config_ID, 
+                        "Timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                        }
                     try:
                         pattern={'PKey' : entry['PKey']}
                         count_documents = db[col].count_documents(pattern)

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/hsbench/hsbench_DBupdate.py
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/hsbench/hsbench_DBupdate.py
@@ -186,11 +186,11 @@ def push_data(files, host, db, Build, Version, Branch , OS):
                         'Percentage_full' : pc_full ,
                         'Name': 'Hsbench',
                         'Operation': operation,
-                        'Object_Size' : obj_size,
+                        'Object_Size' : str(obj_size.upper()),
                         'Buckets' : buckets,
                         'Objects' : objects,
                         'Sessions' : sessions,
-                        'PKey' : Version[0]+'_'+Branch[0].upper()+'_'+Build+'_ITR'+str(iteration)+'_'+str(nodes_num)+'N_'+str(clients_num)+'C_'+str(pc_full)+'PC_'+str(custom).upper()+'_HSB_'+str(obj_size)+'_'+str(buckets)+'_'+operation[0].upper()+'_'+str(sessions) ,
+                        'PKey' : Version[0]+'_'+Branch[0].upper()+'_'+Build+'_ITR'+str(iteration)+'_'+str(nodes_num)+'N_'+str(clients_num)+'C_'+str(pc_full)+'PC_'+str(custom).upper()+'_HSB_'+str(obj_size.upper())+'_'+str(buckets)+'_'+operation[0].upper()+'_'+str(sessions) ,
                         #Version_Branch_Build_Iteration_NodeCount_ClientCount_PercentFull_Benchmark_ObjSize_NoOfBuckets_Operation_Sessions
                     }
 


### PR DESCRIPTION
Signed-off-by: Rahul Ranjan <rahul.ranjan@seagate.com>

Implemented fix for Object sizes having different formats in DB. 
In order to implement uniformity for the Benchmarking tools entry in DB changed the following : 

1. Removed any Empty space in object size value
2. Changed the Object size to Upper case value so that it does represent correct size . 
3. For S3Bench to have same set of entries as other tools added entries for Sessions , Objects and Buckets. 

NB for Point 2 : 
```
What's the difference between megabits and megabytes?

One megabyte is equal to eight megabits, but the terms are used in specific ways: Megabits per second (mbps) are generally used to describe the speed of an Internet connection, whereas megabytes (MB) usually refer to the size of a file or storage space.

```
Ref: https://volo.net/faq/whats-the-difference-between-megabits-and-megabytes