### PR TITLE
PerfLine: Fixed iostat and blktrace stats on VM

### DIFF
--- a/performance/PerfLine/roles/perfline_setup/files/webui/views/dstat_img.py
+++ b/performance/PerfLine/roles/perfline_setup/files/webui/views/dstat_img.py
@@ -32,7 +32,7 @@ def serve_dstat_imgs(tid, node_id, img_type):
     location = cache.get_location(tid)
     path_to_stats = f'{location}/result_{tid}/stats'
     nodes_stat_dirs = [join(path_to_stats, f) for f in os.listdir(
-        path_to_stats) if isdir(join(path_to_stats, f))]
+        path_to_stats) if isdir(join(path_to_stats, f)) and not "addb" in f]
 
     path_to_img = join(
         nodes_stat_dirs[int(node_id)], 'dstat', img_type + '.png')

--- a/performance/PerfLine/roles/perfline_setup/files/webui/views/report.py
+++ b/performance/PerfLine/roles/perfline_setup/files/webui/views/report.py
@@ -29,7 +29,7 @@ def define_path_for_report_imgs(tid, location):
     path_to_workload = f'{location}/result_{tid}/client'
     path_to_m0crate_logs = f'{location}/result_{tid}/m0crate'
     nodes_stat_dirs = [join(path_to_stats, f) for f in os.listdir(
-        path_to_stats) if isdir(join(path_to_stats, f))]
+        path_to_stats) if isdir(join(path_to_stats, f)) and not "addb" in f]
 
     workload_files = {}
 

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/worker.sh
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/worker.sh
@@ -11,7 +11,7 @@ TOOLS_DIR="$SCRIPT_DIR/../../chronometry"
 PERFLINE_DIR="$SCRIPT_DIR/../"
 STAT_DIR="$SCRIPT_DIR/../stat"
 BUILD_DEPLOY_DIR="$SCRIPT_DIR/../../build_deploy"
-PUBLIC_DATA_INTERFACE=$(ip addr show | egrep 'data0|enp179s0|enp175s0f0' | grep -Po 'inet \K[\d.]+')
+PUBLIC_DATA_INTERFACE=$(ip addr show | egrep 'data0|enp179s0|enp175s0f0|eth0' | grep -Po 'inet \K[\d.]+')
 
 source "$SCRIPT_DIR/../../perfline.conf"
 

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/stat/stop_stats_service.sh
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/stat/stop_stats_service.sh
@@ -76,7 +76,7 @@ function blktrace_service_stop()
      done
      
      pushd /var/perfline/blktrace.$(hostname -s)
-     for d in $(ls -1 | grep dm | awk -F. '{print $1}' | sort | uniq); do
+     for d in $(ls -1 | grep blktrace | awk -F. '{print $1}' | sort | uniq); do
          echo $d
          blkparse -i "$d.blktrace.*" -d $d.dump -O
          iowatcher -t $d.dump -o $d.aggregated.svg
@@ -85,7 +85,7 @@ function blktrace_service_stop()
          done
      done
      
-     dumps=$(ls -1 | grep "dm.*dump" | awk '{print "-t "$1}' | tr '\n' ' ')
+     dumps=$(ls -1 | grep "dump" | awk '{print "-t "$1}' | tr '\n' ' ')
      iowatcher $dumps -o node.$(hostname -s).aggregated.svg
      for graph in io tput latency queue_depth iops; do
          iowatcher $dumps -o node.$(hostname -s).$graph.svg -O $graph


### PR DESCRIPTION
Fixed PerfLine and webui scripts to draw iostat and
blktrace/iowatcher plots on single-node VM PerfLine
installation.

Signed-off-by: Maxim Malezhin <maxim.malezhin@seagate.com>