### PR TITLE
EOS-22774: Configure LNET and IB (ko2iblnd.ko)

### DIFF
--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/core/tasks.py
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/core/tasks.py
@@ -180,6 +180,18 @@ def update_configs(conf, log_dir):
                 options.append('--hare-dix-spare-units')
                 options.append(hare['dix']['spare_units'])
 
+        if 'lnet' in conf['configuration']:
+            lnet = conf['configuration']['lnet']
+            if 'custom_conf' in lnet:
+                options.append('--lnet-custom-conf')
+                options.append(lnet['custom_conf'])
+            
+        if 'ko2iblnd' in conf['configuration']:
+            ib = conf['configuration']['ko2iblnd']
+            if 'custom_conf' in ib:
+                options.append('--ib-custom-conf')
+                options.append(ib['custom_conf'])
+            
         update_configs = plumbum.local["scripts/conf_customization/update_configs.sh"]
         mv = plumbum.local['mv']
         try:

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/core/validator.py
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/core/validator.py
@@ -85,6 +85,20 @@ def get_schema_motr():
                         'S3_MOTR_CONFIG': {'type': 'dict', 'required': False, 'empty': False},
                         'S3_THIRDPARTY_CONFIG': {'type': 'dict', 'required': False, 'empty': False},
                     }
+                },
+                'lnet': {
+                    'required': False,
+                    'type': 'dict',
+                    'schema': {
+                        'custom_conf': {'type': 'string', 'required': False, 'empty': False},
+                    }
+                },
+                'ko2iblnd': {
+                    'required': False,
+                    'type': 'dict',
+                    'schema': {
+                        'custom_conf': {'type': 'string', 'required': False, 'empty': False},
+                    }
                 }
             }
              

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/conf_customization/restore_orig_configs.sh
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/conf_customization/restore_orig_configs.sh
@@ -42,6 +42,12 @@ HAPROXY_CONFIG_BACKUP="/etc/haproxy/.perfline__haproxy.cfg__backup"
 S3_CONFIG="/opt/seagate/cortx/s3/conf/s3config.yaml"
 S3_CONFIG_BACKUP="/opt/seagate/cortx/s3/conf/.perfline__s3config.yaml__backup"
 
+LNET_CONFIG="/etc/modprobe.d/lnet.conf"
+LNET_CONFIG_BACKUP="/etc/modprobe.d/.perfline__lnet.conf__backup"
+
+IB_CONFIG="/etc/modprobe.d/ko2iblnd.conf"
+IB_CONFIG_BACKUP="/etc/modprobe.d/.perfline__ko2iblnd.conf__backup"
+
 function restore_hare_config()
 {
     $EX_SRV "if [[ -e $HARE_CONFIG_BACKUP ]]; then mv -f $HARE_CONFIG_BACKUP $HARE_CONFIG; fi"
@@ -62,12 +68,34 @@ function restore_s3_config()
     $EX_SRV "if [[ -e $S3_CONFIG_BACKUP ]]; then mv -f $S3_CONFIG_BACKUP $S3_CONFIG; fi"
 }
 
+function restore_lnet_config()
+{
+    $EX_SRV "if [[ -e $LNET_CONFIG_BACKUP ]]; then mv -f $LNET_CONFIG_BACKUP $LNET_CONFIG; fi"
+}
+
+function restore_ib_config()
+{
+    $EX_SRV "if [[ -e $IB_CONFIG_BACKUP ]]; then mv -f $IB_CONFIG_BACKUP $IB_CONFIG; fi"
+}
+
+function apply_configs()
+{
+    set +e
+    $EX_SRV "systemctl stop lnet"
+    $EX_SRV "systemctl start lnet"
+    $EX_SRV "systemctl restart haproxy"
+    set -e
+}
+
 function main()
 {
     restore_hare_config
     restore_motr_config
     restore_haproxy_config
     restore_s3_config
+    restore_lnet_config
+    restore_ib_config
+    apply_configs
 }
 
 main $@

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/conf_customization/update_configs.sh
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/conf_customization/update_configs.sh
@@ -42,6 +42,11 @@ HAPROXY_CONFIG_BACKUP="/etc/haproxy/.perfline__haproxy.cfg__backup"
 S3_CONFIG="/opt/seagate/cortx/s3/conf/s3config.yaml"
 S3_CONFIG_BACKUP="/opt/seagate/cortx/s3/conf/.perfline__s3config.yaml__backup"
 
+LNET_CONFIG="/etc/modprobe.d/lnet.conf"
+LNET_CONFIG_BACKUP="/etc/modprobe.d/.perfline__lnet.conf__backup"
+
+IB_CONFIG="/etc/modprobe.d/ko2iblnd.conf"
+IB_CONFIG_BACKUP="/etc/modprobe.d/.perfline__ko2iblnd.conf__backup"
 
 function parse_args()
 {
@@ -97,6 +102,14 @@ function parse_args()
                 S3_PARAMS="$S3_PARAMS $1 \"$2\""
                 shift
                 ;;
+	    --lnet-custom-conf)
+		LNET_CUSTOM_CONF="$2"
+		shift
+		;;
+	    --ib-custom-conf)
+		IB_CUSTOM_CONF="$2"
+		shift
+		;;
             *)
                 echo -e "Invalid option: $1\nUse --help option"
                 exit 1
@@ -112,6 +125,8 @@ function check_backup_files()
     $EX_SRV "[[ ! -e $MOTR_CONFIG_BACKUP ]]"
     $EX_SRV "[[ ! -e $HAPROXY_CONFIG_BACKUP ]]"
     $EX_SRV "[[ ! -e $S3_CONFIG_BACKUP ]]"
+    $EX_SRV "[[ ! -e $LNET_CONFIG_BACKUP ]]"
+    $EX_SRV "[[ ! -e $IB_CONFIG_BACKUP ]]"
 }
 
 function save_original_configs()
@@ -120,6 +135,8 @@ function save_original_configs()
     save_original_motr_config
     save_original_haproxy_config
     save_original_s3_config
+    save_original_lnet_config
+    save_original_ib_config
 }
 
 function save_original_hare_config()
@@ -142,12 +159,24 @@ function save_original_s3_config()
     $EX_SRV cp $S3_CONFIG $S3_CONFIG_BACKUP
 }
 
+function save_original_lnet_config()
+{
+    $EX_SRV cp $LNET_CONFIG $LNET_CONFIG_BACKUP
+}
+
+function save_original_ib_config()
+{
+    $EX_SRV cp $IB_CONFIG $IB_CONFIG_BACKUP
+}
+
 function customize_configs()
 {
     customize_hare_config
     customize_motr_config
     customize_haproxy_config
     customize_s3_config
+    customize_lnet_config
+    customize_ib_config
 }
 
 function customize_hare_config()
@@ -231,6 +260,28 @@ function customize_s3_config()
     fi
 }
 
+function customize_lnet_config()
+{
+    if [[ -n "$LNET_CUSTOM_CONF" ]]; then
+        $EX_SRV "scp root@$(hostname):$LNET_CUSTOM_CONF $LNET_CONFIG"
+    fi
+}
+
+function customize_ib_config()
+{
+    if [[ -n "$IB_CUSTOM_CONF" ]]; then
+        $EX_SRV "scp root@$(hostname):$IB_CUSTOM_CONF $IB_CONFIG"
+    fi
+}
+
+function apply_configs()
+{
+    set +e
+    $EX_SRV "systemctl stop lnet"
+    $EX_SRV "systemctl start lnet"
+    $EX_SRV "systemctl restart haproxy"
+    set -e
+}
 
 function main()
 {
@@ -238,6 +289,7 @@ function main()
     check_backup_files
     save_original_configs
     customize_configs
+    apply_configs
 }
 
 main "$@"


### PR DESCRIPTION
This patch provides ability to specify custom LNET and IB
configuration files during submitting of PerfLine workload.

Signed-off-by: Maxim Malezhin <maxim.malezhin@seagate.com>