### PR TITLE
EOS-23490: Disable ADDB analysis by default

### DIFF
--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/core/tasks.py
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/core/tasks.py
@@ -76,6 +76,9 @@ def parse_options(conf, result_dir):
         options.append("--m0trace-files")
     if conf['execution_options']['collect_addb']:
         options.append("--addb-dumps")
+    if 'analyze_addb' in conf['execution_options']:
+        if conf['execution_options']['analyze_addb']:
+            options.append("--addb-analyze")
     if conf['execution_options']['backup_result']:
         options.append("--backup-result")
 

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/core/validator.py
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/core/validator.py
@@ -277,6 +277,7 @@ def get_schema_motr():
                 'mkfs': {'type': 'boolean'},
                 'collect_m0trace': {'type': 'boolean'},
                 'collect_addb': {'type': 'boolean'},
+                'analyze_addb': {'type': 'boolean', 'required': False},
                 'backup_result': {'type': 'boolean'}
             }
         }

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/worker.sh
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/worker.sh
@@ -409,7 +409,7 @@ function collect_artifacts() {
         $SCRIPT_DIR/../../chronometry_v2/fix_reqid_collisions.py --fix-db --db ./m0play.db
     fi
 
-    if [[ -n $S3BENCH ]] && [[ -f "m0play.db" ]]; then
+    if [[ -n $ADDB_ANALYZE ]] && [[ -f "m0play.db" ]]; then
         local m0play_path="$(pwd)/m0play.db"
         local stats_addb="$stats/addb"
         mkdir -p $stats_addb
@@ -625,6 +625,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         -d|--addb-dumps)
             ADDB_DUMPS="1"
+            ;;
+	--addb-analyze)
+            ADDB_ANALYZE="1"
             ;;
         --motr-trace)
             MOTR_TRACE="1"


### PR DESCRIPTION
In order to save time during tests executions, it was decided
to disable ADDB analysis by default. If ADDB analysis is required,
it can be done either manually or by providing 'analyze_addb' option
in 'execution_options' session.

Signed-off-by: Maxim Malezhin <maxim.malezhin@seagate.com>