### PR TITLE
EOS-24844 :Fixed 'IndexError while uploading s3bench results data to DB'

### DIFF
--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/s3bench/s3bench_DBupdate.py
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/s3bench/s3bench_DBupdate.py
@@ -149,9 +149,11 @@ def insertOperations(files,Build,Version,col,Config_ID,Branch,OS,db): #function 
         obj = "NA"
         sessions=1
         f = open(file)
-        lines = f.readlines()[-200:]
+        linecount=len(f.readlines())
+        f = open(file)
+        lines = f.readlines()[-linecount:]
         count=0
-        while count<200:
+        while count<linecount:
             if '''"numSamples":''' in lines[count].strip().replace(" ", ""):
                 r=lines[count].strip().replace(" ", "").split(":")
                 Objects = int(r[1].replace(",", ""))


### PR DESCRIPTION
Signed-off-by: Rahul Ranjan <rahul.ranjan@seagate.com>
Fixed the issue by removing numerical values with actual number of lines in the result file. 