### PR TITLE
EOS-24552 : Using default csmadmin account to create s3account

### DIFF
--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/S3UserCreation/main_createusers.py
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/S3UserCreation/main_createusers.py
@@ -8,6 +8,7 @@ from subprocess import Popen, PIPE
 import yaml
 import json
 
+'''
 def makeconfig(name):  #function for connecting with configuration file
 	with open(name) as config_file:
 		configs = yaml.load(config_file, Loader=yaml.FullLoader)
@@ -30,6 +31,7 @@ def createcsmadmin():
     r = requests.post(url, data={"username": "admin", "password": "Seagate@1"}, headers=headers, verify=False)
     print(r.json())
     #data = r.json()"""
+'''
 
 def s3create():
     try:
@@ -69,8 +71,8 @@ def s3create():
 
 
 def main(argv):
-    print("**************************  CSM Admin Creation  **************************")
-    createcsmadmin()
+#    print("**************************  CSM Admin Creation  **************************")
+#    createcsmadmin()
     print("\n**************************  s3 User Creation  **************************")
     s3create()
     

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/tasks/main.yml
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/tasks/main.yml
@@ -27,16 +27,6 @@
    delegate_to: "{{ item }}"
    with_items: "{{ groups['all'] }}"
  
- - name: copying s3account.yml file 
-   copy:
-      src: vars/s3account.yml
-      dest: /root/PerfProBenchmark/
-      owner: root
-      group: root
-      mode: '0644' 
-   delegate_to: "{{ item }}"
-   with_items: "{{ groups['all'] }}"
-
  - name: copying main.yml file 
    copy:
      src: vars/main.yml
@@ -46,6 +36,21 @@
      mode: '0644'
    delegate_to: "{{ item }}"
    with_items: "{{ groups['all'] }}"
+
+ - name: updating s3account.yml file with mgmt_vip from config.yml
+   shell: |
+      mgmt_vip=`grep MGMT_VIP roles/perfpro_deployment/vars/config.yml | cut -d ":" -f2`
+      sed -i "s/ip : /ip : $mgmt_vip/" roles/benchmark/vars/s3account.yml
+
+ - name: copying s3account.yml file to client
+   copy:
+      src: vars/s3account.yml
+      dest: /root/PerfProBenchmark/
+      owner: root
+      group: root
+      mode: '0644'
+   delegate_to: "{{ item }}"
+   with_items: "{{ groups['clients'] }}"
 
  - name: Create S3 account
    command: python3 /root/PerfProBenchmark/S3UserCreation/main_createusers.py /root/PerfProBenchmark/s3account.yml 

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/vars/s3account.yml
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/vars/s3account.yml
@@ -1,12 +1,11 @@
 ---
-MGMT_VIP: 10.237.65.69
 Restcall:
-  ip : "10.237.65.69"
-  port : 28100
+  ip :  
+  port : 443 
   jsonfile : 'rest_call.json'
   csm_admin_user :
-    username: "admin"
-    password: "Seagate@1"
+    username: "cortxadmin"
+    password: "Cortxadmin@123"
   csm_user_manage:
     username: "csm_user_manage"
     password: "Testuser@123"

--- a/performance/PerfPro/perfPro-deployment/roles/perfpro_deployment/vars/config.yml
+++ b/performance/PerfPro/perfPro-deployment/roles/perfpro_deployment/vars/config.yml
@@ -1,6 +1,7 @@
 ---
 REIMAGE: 'No'
 # For host file update : add for more nodes/clients in environment or remove if less nodes/clients .
+MGMT_VIP: 
 NODES:  
   - 1:  # node_number_srvnode-1: hostname of node1 .
   - 2:  # node_number_srvnode-2: hostname of node2 .


### PR DESCRIPTION
Commented code which creates csmadmin account and making use of default csmadmin account.
Added entry for MGMT_VIP in config.yml and using same to create s3account.

Signed-off-by: Rajesh Deshmukh <rajesh.deshmukh@seagate.com>