### PR TITLE
EOS-24512 Adding support for configurable endpoints in PerfPro

### DIFF
--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/cosbench/configure.sh
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/cosbench/configure.sh
@@ -7,7 +7,7 @@ set -e
 
 #s3_setup_label="$s3_setup_label.properties"
 s3_setup_label=s3setup.properties
-s3_url_endpoint=https://s3.seagate.com
+s3_url_endpoint="$1"
 s3_access_key=`cat /root/.aws/credentials | grep -A 3 default | grep aws_access_key_id | cut -d " " -f3`
 s3_secret_key=`cat /root/.aws/credentials | grep -A 3 default | grep secret_access_key | cut -d " " -f3`
 echo "s3_endpoint:$s3_url_endpoint" > "$s3_setup_label"

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/cosbench/s3cosbench_benchmark.sh
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/cosbench/s3cosbench_benchmark.sh
@@ -20,6 +20,7 @@ CONFIG="/root/PerfProBenchmark/config.yml"
 #ITERATION=$(yq -r .ITERATION $CONFIG)
 
 BUILD=`python3 /root/PerfProBenchmark/read_build.py $CONFIG 2>&1`
+ENDPOINTS=`python3 /root/PerfProBenchmark/get_param.py $CONFIG`
 RESULT_DIR=/root/PerfProBenchmark/perfpro_build$BUILD/results
 
 validate_args() {
@@ -64,7 +65,7 @@ config_s3workloads() {
                     echo "no_of_buckets=$bucket" >> $workload_file
                     echo "workload_type=$workload_type" >> $workload_file
                     echo "run_time_in_seconds=$run_time_in_seconds" >> $workload_file                    
-                    sh configure.sh
+                    sh configure.sh "$ENDPOINTS"
                     sh run-test.sh --s3setup s3setup.properties --controller $HOSTNAME --workload $workload_file >> $TOOL_DIR/workloads 
                     check_completion `tail -n 3 $TOOL_DIR/workloads | grep Accepted | cut -d ":" -f2 | tr -d ' '`
                     echo "Cosbench Triggered for worker: $clients sample: $sample obj_size:$io_size bucket:$bucket"

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/degraded_read/degradedread_hsbench.sh
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/degraded_read/degradedread_hsbench.sh
@@ -12,7 +12,7 @@ MAX_ATTEMPT=1
 NO_OF_THREADS=""			
 NO_OF_OBJECTS=""			
 REGION=US				
-ENDPOINTS=https://s3.seagate.com		
+#ENDPOINTS=https://s3.seagate.com		
 COUNT=0
 SIZE_OF_OBJECTS=""
 JSON_FILENAME=				
@@ -23,6 +23,7 @@ TIMESTAMP=`date +'%Y-%m-%d_%H:%M:%S'`
 MAIN="/root/PerfProBenchmark/main.yml"
 CONFIG="/root/PerfProBenchmark/config.yml"
 BUILD=`python3 /root/PerfProBenchmark/read_build.py $CONFIG 2>&1`
+ENDPOINTS=`python3 /root/PerfProBenchmark/get_param.py $CONFIG`
 RESULT_DIR=/root/PerfProBenchmark/perfpro_build$BUILD/results/degraded_read
 validate_args() {
 

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/degraded_read/degradedread_s3benchmark.sh
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/degraded_read/degradedread_s3benchmark.sh
@@ -5,7 +5,7 @@ SECRET_KEY=`cat /root/.aws/credentials | grep -A 3 default | grep secret_access_
 BINPATH=/root/PerfProBenchmark/s3bench
 CURRENTPATH=`pwd`
 BENCHMARKLOG=$CURRENTPATH/dr_s3b.log
-ENDPOINTS=https://s3.seagate.com         
+#ENDPOINTS=https://s3.seagate.com         
 BUCKETNAME="seagate-dr"
 TIMESTAMP=`date +'%Y-%m-%d_%H:%M:%S'`
 CLIENTS=""     
@@ -17,6 +17,7 @@ MAIN="/root/PerfProBenchmark/main.yml"
 CONFIG="/root/PerfProBenchmark/config.yml"
 LOG_COLLECT="/root/PerfProBenchmark/collect_logs.py"
 BUILD=`python3 /root/PerfProBenchmark/read_build.py $CONFIG 2>&1`
+ENDPOINTS=`python3 /root/PerfProBenchmark/get_param.py $CONFIG`
 RESULT_DIR=/root/PerfProBenchmark/perfpro_build$BUILD/results/degraded_read/
 
 validate_args() {

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/get_config.py
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/get_config.py
@@ -1,0 +1,13 @@
+import os
+import sys
+import yaml
+import urllib.request
+import re
+
+
+conf_yaml = open(sys.argv[1])
+parse_conf = yaml.load(conf_yaml , Loader=yaml.FullLoader)
+param=parse_conf.get('END_POINTS')
+
+					
+print(param)

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/hsbench/run_benchmark.sh
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/hsbench/run_benchmark.sh
@@ -12,7 +12,7 @@ MAX_ATTEMPT=1
 NO_OF_THREADS=""			
 NO_OF_OBJECTS=""			
 REGION=US				
-ENDPOINTS=https://s3.seagate.com		
+#ENDPOINTS=https://s3.seagate.com		
 COUNT=0
 SIZE_OF_OBJECTS=""
 JSON_FILENAME=				
@@ -23,6 +23,7 @@ MAIN="/root/PerfProBenchmark/main.yml"
 CONFIG="/root/PerfProBenchmark/config.yml"
 #ITERATION=$(yq -r .ITERATION $CONFIG)
 BUILD=`python3 /root/PerfProBenchmark/read_build.py $CONFIG 2>&1`
+ENDPOINTS=`python3 /root/PerfProBenchmark/get_param.py $CONFIG`
 RESULT_DIR=/root/PerfProBenchmark/perfpro_build$BUILD/results
 validate_args() {
 

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/pre_fill/pre_fill.py
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/pre_fill/pre_fill.py
@@ -11,6 +11,7 @@ nodes=parse_conf.get('NODES')
 node1 = nodes[0][1]
 passwd=parse_conf.get('CLUSTER_PASS')
 PC_full=parse_conf.get('PC_FULL')
+endpoints=parse_conf.get('END_POINTS')
 
 prebench=sys.argv[2]
 
@@ -53,7 +54,7 @@ def fill_data(pre_fill):
     num_clients=200
     print('pre_fill size(MB) :' , Pre_fill_mb , '\nNumber of objects per bucket(10 buckets)(128Mb Object size)', num_obj_per_bucket )
     for i in range(num_bucket):
-        os.system('sh '+prebench+' -nc '+str(num_clients)+' -ns '+str(num_obj_per_bucket)+' -s '+str(obj_size)+'Mb')
+        os.system('sh '+prebench+' -ep '+str(endpoints)+' -nc '+str(num_clients)+' -ns '+str(num_obj_per_bucket)+' -s '+str(obj_size)+'Mb')
 
 
 def pre_fill_calc():

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/pre_fill/prefill_s3bench.sh
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/pre_fill/prefill_s3bench.sh
@@ -4,9 +4,10 @@ SECRET_KEY=`cat /root/.aws/credentials | grep -A 3 default | grep secret_access_
 BINPATH=/root/PerfProBenchmark/s3bench
 CURRENTPATH=/root/PerfProBenchmark
 BENCHMARKLOG=$CURRENTPATH/prefill/
-ENDPOINTS=https://s3.seagate.com         
+#ENDPOINTS=https://s3.seagate.com         
 BUCKETNAME="prefill"
 TIMESTAMP=`date +'%Y-%m-%d_%H:%M:%S'`
+ENDPOINTS=""
 CLIENTS=""     
 NUMSAMPLES=""     
 IO_SIZE=""
@@ -14,14 +15,15 @@ IO_SIZE=""
 
 validate_args() {
 
-        if [[ -z $CLIENTS ]] || [[ -z $NUMSAMPLES ]] || [[ -z $IO_SIZE ]] ; then
+        if [[ -z $ENDPOINTS ]] || [[ -z $CLIENTS ]] || [[ -z $NUMSAMPLES ]] || [[ -z $IO_SIZE ]] ; then
                 show_usage
         fi
 
 }
 
 show_usage() {
-        echo -e "\n \t  Usage : ./run_s3benchmark.sh -nc NO_OF_CLIENTS -ns NO_OF_SAMPLES -s \"iosize\"   \n"
+        echo -e "\n \t  Usage : ./run_s3benchmark.sh -ep END_POINTS -nc NO_OF_CLIENTS -ns NO_OF_SAMPLES -s \"iosize\"   \n"
+        echo -e "\t -ep\t:\t endpoints \n"
         echo -e "\t -nc\t:\t number of clients \n"
         echo -e "\t -ns\t:\t number of samples\n"
         echo -e "\t -s\t:\t size of the objects in bytes\n"       
@@ -76,6 +78,10 @@ echo 'Successfully completed'
 while [ ! -z $1 ]; do
         
         case $1 in
+        -ep)     shift
+                ENDPOINTS="$1"
+        ;;
+
         -nc)     shift
                 CLIENTS="$1"
         ;;

--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/s3bench/run_s3benchmark.sh
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/s3bench/run_s3benchmark.sh
@@ -5,7 +5,7 @@ SECRET_KEY=`cat /root/.aws/credentials | grep -A 3 default | grep secret_access_
 BINPATH=/root/PerfProBenchmark/s3bench
 CURRENTPATH=`pwd`
 BENCHMARKLOG=$CURRENTPATH/benchmark.log
-ENDPOINTS=https://s3.seagate.com         
+#ENDPOINTS=https://s3.seagate.com         
 BUCKETNAME="seagate"
 TIMESTAMP=`date +'%Y-%m-%d_%H:%M:%S'`
 CLIENTS=""     
@@ -15,6 +15,7 @@ MAIN="/root/PerfProBenchmark/main.yml"
 CONFIG="/root/PerfProBenchmark/config.yml"
 LOG_COLLECT="/root/PerfProBenchmark/collect_logs.py"
 BUILD=`python3 /root/PerfProBenchmark/read_build.py $CONFIG 2>&1`
+ENDPOINTS=`python3 /root/PerfProBenchmark/get_param.py $CONFIG`         
 RESULT_DIR=/root/PerfProBenchmark/perfpro_build$BUILD/results
 
 validate_args() {

--- a/performance/PerfPro/perfPro-deployment/roles/perfpro_deployment/vars/config.yml
+++ b/performance/PerfPro/perfPro-deployment/roles/perfpro_deployment/vars/config.yml
@@ -21,7 +21,8 @@ SERVICE_USER:
 SERVICE_PASS:
 
 # For PerfPro MongoDB related Entries
-#ITERATION: 1 # <removed iteration> 
+#ITERATION: 1 # <removed iteration>
+END_POINTS: https://s3.seagate.com
 PC_FULL: 30 # Select for system percentage full before test. 
 OVERWRITE: False # select True or False to overwrite the DB entries for same Primary Key
 CUSTOM: NA # Default is NA. Update with single string for special config eg: SSD, DIEnabled, PODsetup etc


### PR DESCRIPTION
This PR fixes a limitation of PerfPro to only use hardcoded s3 endpoint for benchmarking. In this PR, S3 endpoints are made configurable via config.yml file which is file to get user inputs for each PerfPro run. Any endpoint passed to config.yml via newly added parameter END_POINT: <any endpoint> will be used by PerfPro.

Modules which got impacted are :-
Under PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark
1. s3bench run shell script - run_s3benchmark.sh
2. cosbench run shell script - configure.sh & s3cosbench_benchmark.sh
3. hsbench run shell script - run_benchmark.sh
4. degraded read workload shell script - degradedread_hsbench.sh & degradedread_s3benchmark.sh
5. prefill scripts - pre_fill.py & prefill_s3bench.sh

Under performance/PerfPro/perfPro-deployment/roles/perfpro_deployment/vars
6. config.yml has new field END_POINT


Signed-off-by: Tushar Jain <tushar.1.jain@seagate.com>