### PR TITLE
EOS-25101 : Fixed Verbose logs of HSBench runs are not getting preserved

### DIFF
--- a/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/hsbench/run_benchmark.sh
+++ b/performance/PerfPro/perfPro-deployment/roles/benchmark/files/PerfProBenchmark/hsbench/run_benchmark.sh
@@ -12,7 +12,7 @@ MAX_ATTEMPT=1
 NO_OF_THREADS=""			
 NO_OF_OBJECTS=""			
 REGION=US				
-ENDPOINTS=https://s3.seagate.com		
+#ENDPOINTS=https://s3.seagate.com		
 COUNT=0
 SIZE_OF_OBJECTS=""
 JSON_FILENAME=				
@@ -21,6 +21,7 @@ TIMESTAMP=`date +'%Y-%m-%d_%H:%M:%S'`
 MAIN="/root/PerfProBenchmark/main.yml"
 CONFIG="/root/PerfProBenchmark/config.yml"
 BUILD=`python3 /root/PerfProBenchmark/read_build.py $CONFIG 2>&1`
+ENDPOINTS=`python3 /root/PerfProBenchmark/get_param.py $CONFIG`
 RESULT_DIR=/root/PerfProBenchmark/perfpro_build$BUILD/results
 validate_args() {
 


### PR DESCRIPTION
HSbench Verbose logs are saved as per below example: 

`[root@ssc-vm-g3-rhev4-0133 benchmark.log]# tree
.
└── hsbench
    ├── numclients_1
    │   └── buckets_1
    │       └── 100K
    │           ├── hsbench_object_100K_numsamples_100_buckets_1_sessions_1.json
    │           └── object_100K_numsamples_100_buckets_1_sessions_1_output.log
    ├── numclients_20
    │   └── buckets_1
    │       └── 100K
    │           ├── hsbench_object_100K_numsamples_100_buckets_1_sessions_20.json
    │           └── object_100K_numsamples_100_buckets_1_sessions_20_output.log
    └── numclients_3
        └── buckets_1
            └── 100K
                ├── hsbench_object_100K_numsamples_100_buckets_1_sessions_3.json
                └── object_100K_numsamples_100_buckets_1_sessions_3_output.log

10 directories, 6 files
`



Signed-off-by: Rahul Ranjan <rahul.ranjan@seagate.com>