### PR TITLE
EOS-25541 Multi-Client Support for PerfPro Results and Backup

### DIFF
--- a/performance/PerfPro/roles/benchmark/tasks/main.yml
+++ b/performance/PerfPro/roles/benchmark/tasks/main.yml
@@ -144,18 +144,21 @@
    shell: "date +%F-%H-%M-%S"
    register: tstamp
 
-
- - name: Rename perfpro_build<build> directory
-   shell: mv /root/PerfProBenchmark/perfpro_build{{ build.stdout }} /root/PerfProBenchmark/perfpro_build{{ build.stdout }}_{{ tstamp.stdout }}
+ - name: Rearranging perfpro_build<build> directory data on clients
+   shell: |
+      mkdir /root/PerfProBenchmark/perfpro_build{{ build.stdout }}_{{ tstamp.stdout }}
+      mv /root/PerfProBenchmark/perfpro_build{{ build.stdout }} /root/PerfProBenchmark/perfpro_build{{ build.stdout }}_{{ tstamp.stdout }}/{{ item }}
    delegate_to: "{{ item }}"
    with_items: "{{ groups['clients'] }}"
 
+ - name: Collecting Results from all clients
+   command: scp -r {{ hostvars[item]['ansible_host'] }}:/root/PerfProBenchmark/perfpro_build{{ build.stdout }}_{{ tstamp.stdout }}/{{ item }} /root/PerfProBenchmark/perfpro_build{{ build.stdout }}_{{ tstamp.stdout }}/
+   delegate_to: "clientnode-1"
+   loop: "{{ groups['clients'] }}"
+   when: item != "clientnode-1"
 
  - name: Archiving artifacts to NFS server
    shell: |
      cd /root/PerfProBenchmark/ 
      python3 /root/PerfProBenchmark/archive_artifacts.py /root/PerfProBenchmark/config.yml perfpro_build{{ build.stdout }}_{{ tstamp.stdout }}
-   delegate_to: "{{ item }}"
-   with_items: "{{ groups['clients'] }}"
-
-
+   delegate_to: "clientnode-1"


### PR DESCRIPTION
Signed-off-by: Tushar Jain <tushar.1.jain@seagate.com>
1. Updated main.yml task under benchmark role for properly arranging Result Logs clientwise on each client.
2. Then, collecting all such results into one master result directory log on first client
3. Then, archiving and backing up everything from first client to NFS Backup location.

Final Result Direcotry Log looks as below for a two client scenario

```
perfpro_build433_2021-11-28-07-27-14
├── clientnode-1
│   ├── configs
│   ├── logs
│   │   └── ansible
│   │       └── ansible.log-2021-11-28-1638108928
│   └── results
│       ├── hsbench
│       │   ├── numclients_1
│       │   │   └── buckets_1
│       │   │       ├── 16Mb
│       │   │       │   ├── hsbench_object_16Mb_numsamples_2_buckets_1_sessions_1.json
│       │   │       │   └── object_16Mb_numsamples_2_buckets_1_sessions_1_output.log
│       │   │       ├── 1Kb
│       │   │       │   ├── hsbench_object_1Kb_numsamples_2_buckets_1_sessions_1.json
│       │   │       │   └── object_1Kb_numsamples_2_buckets_1_sessions_1_output.log
│       │   │       └── 256Kb
│       │   │           ├── hsbench_object_256Kb_numsamples_2_buckets_1_sessions_1.json
│       │   │           └── object_256Kb_numsamples_2_buckets_1_sessions_1_output.log
│       │   ├── numclients_2
│       │   │   └── buckets_1
│       │   │       ├── 16Mb
│       │   │       │   ├── hsbench_object_16Mb_numsamples_2_buckets_1_sessions_2.json
│       │   │       │   └── object_16Mb_numsamples_2_buckets_1_sessions_2_output.log
│       │   │       ├── 1Kb
│       │   │       │   ├── hsbench_object_1Kb_numsamples_2_buckets_1_sessions_2.json
│       │   │       │   └── object_1Kb_numsamples_2_buckets_1_sessions_2_output.log
│       │   │       └── 256Kb
│       │   │           ├── hsbench_object_256Kb_numsamples_2_buckets_1_sessions_2.json
│       │   │           └── object_256Kb_numsamples_2_buckets_1_sessions_2_output.log
│       │   └── numclients_3
│       │       └── buckets_1
│       │           ├── 16Mb
│       │           │   ├── hsbench_object_16Mb_numsamples_3_buckets_1_sessions_3.json
│       │           │   └── object_16Mb_numsamples_3_buckets_1_sessions_3_output.log
│       │           ├── 1Kb
│       │           │   ├── hsbench_object_1Kb_numsamples_3_buckets_1_sessions_3.json
│       │           │   └── object_1Kb_numsamples_3_buckets_1_sessions_3_output.log
│       │           └── 256Kb
│       │               ├── hsbench_object_256Kb_numsamples_3_buckets_1_sessions_3.json
│       │               └── object_256Kb_numsamples_3_buckets_1_sessions_3_output.log
│       └── s3bench
│           ├── numclients_1
│           │   └── buckets_1
│           │       ├── 16Mb
│           │       │   ├── report.s3bench
│           │       │   └── s3bench_object_16Mb_numsamples_2_buckets_1_sessions_1.log
│           │       ├── 1Kb
│           │       │   ├── report.s3bench
│           │       │   └── s3bench_object_1Kb_numsamples_2_buckets_1_sessions_1.log
│           │       └── 256Kb
│           │           ├── report.s3bench
│           │           └── s3bench_object_256Kb_numsamples_2_buckets_1_sessions_1.log
│           ├── numclients_2
│           │   └── buckets_1
│           │       ├── 16Mb
│           │       │   ├── report.s3bench
│           │       │   └── s3bench_object_16Mb_numsamples_2_buckets_1_sessions_2.log
│           │       ├── 1Kb
│           │       │   ├── report.s3bench
│           │       │   └── s3bench_object_1Kb_numsamples_2_buckets_1_sessions_2.log
│           │       └── 256Kb
│           │           ├── report.s3bench
│           │           └── s3bench_object_256Kb_numsamples_2_buckets_1_sessions_2.log
│           └── numclients_3
│               └── buckets_1
│                   ├── 16Mb
│                   │   ├── report.s3bench
│                   │   └── s3bench_object_16Mb_numsamples_3_buckets_1_sessions_3.log
│                   ├── 1Kb
│                   │   ├── report.s3bench
│                   │   └── s3bench_object_1Kb_numsamples_3_buckets_1_sessions_3.log
│                   └── 256Kb
│                       ├── report.s3bench
│                       └── s3bench_object_256Kb_numsamples_3_buckets_1_sessions_3.log
└── clientnode-2
    ├── configs
    ├── logs
    │   └── ansible
    │       └── ansible.log-2021-11-28-1638108928
    └── results
        ├── hsbench
        │   ├── numclients_1
        │   │   └── buckets_1
        │   │       ├── 16Mb
        │   │       │   ├── hsbench_object_16Mb_numsamples_2_buckets_1_sessions_1.json
        │   │       │   └── object_16Mb_numsamples_2_buckets_1_sessions_1_output.log
        │   │       ├── 1Kb
        │   │       │   ├── hsbench_object_1Kb_numsamples_2_buckets_1_sessions_1.json
        │   │       │   └── object_1Kb_numsamples_2_buckets_1_sessions_1_output.log
        │   │       └── 256Kb
        │   │           ├── hsbench_object_256Kb_numsamples_2_buckets_1_sessions_1.json
        │   │           └── object_256Kb_numsamples_2_buckets_1_sessions_1_output.log
        │   ├── numclients_2
        │   │   └── buckets_1
        │   │       ├── 16Mb
        │   │       │   ├── hsbench_object_16Mb_numsamples_2_buckets_1_sessions_2.json
        │   │       │   └── object_16Mb_numsamples_2_buckets_1_sessions_2_output.log
        │   │       ├── 1Kb
        │   │       │   ├── hsbench_object_1Kb_numsamples_2_buckets_1_sessions_2.json
        │   │       │   └── object_1Kb_numsamples_2_buckets_1_sessions_2_output.log
        │   │       └── 256Kb
        │   │           ├── hsbench_object_256Kb_numsamples_2_buckets_1_sessions_2.json
        │   │           └── object_256Kb_numsamples_2_buckets_1_sessions_2_output.log
        │   └── numclients_3
        │       └── buckets_1
        │           ├── 16Mb
        │           │   ├── hsbench_object_16Mb_numsamples_3_buckets_1_sessions_3.json
        │           │   └── object_16Mb_numsamples_3_buckets_1_sessions_3_output.log
        │           ├── 1Kb
        │           │   ├── hsbench_object_1Kb_numsamples_3_buckets_1_sessions_3.json
        │           │   └── object_1Kb_numsamples_3_buckets_1_sessions_3_output.log
        │           └── 256Kb
        │               ├── hsbench_object_256Kb_numsamples_3_buckets_1_sessions_3.json
        │               └── object_256Kb_numsamples_3_buckets_1_sessions_3_output.log
        └── s3bench
            ├── numclients_1
            │   └── buckets_1
            │       ├── 16Mb
            │       │   ├── report.s3bench
            │       │   └── s3bench_object_16Mb_numsamples_2_buckets_1_sessions_1.log
            │       ├── 1Kb
            │       │   ├── report.s3bench
            │       │   └── s3bench_object_1Kb_numsamples_2_buckets_1_sessions_1.log
            │       └── 256Kb
            │           ├── report.s3bench
            │           └── s3bench_object_256Kb_numsamples_2_buckets_1_sessions_1.log
            ├── numclients_2
            │   └── buckets_1
            │       ├── 16Mb
            │       │   ├── report.s3bench
            │       │   └── s3bench_object_16Mb_numsamples_2_buckets_1_sessions_2.log
            │       ├── 1Kb
            │       │   ├── report.s3bench
            │       │   └── s3bench_object_1Kb_numsamples_2_buckets_1_sessions_2.log
            │       └── 256Kb
            │           ├── report.s3bench
            │           └── s3bench_object_256Kb_numsamples_2_buckets_1_sessions_2.log
            └── numclients_3
                └── buckets_1
                    ├── 16Mb
                    │   ├── report.s3bench
                    │   └── s3bench_object_16Mb_numsamples_3_buckets_1_sessions_3.log
                    ├── 1Kb
                    │   ├── report.s3bench
                    │   └── s3bench_object_1Kb_numsamples_3_buckets_1_sessions_3.log
                    └── 256Kb
                        ├── report.s3bench
                        └── s3bench_object_256Kb_numsamples_3_buckets_1_sessions_3.log

74 directories, 74 files
```
