### PR TITLE
EOS-26135 Backend change for adding TTFB 99% metric in S3bench DB records

### DIFF
--- a/performance/PerfPro/roles/benchmark/files/PerfProBenchmark/s3bench/s3bench_DBupdate.py
+++ b/performance/PerfPro/roles/benchmark/files/PerfProBenchmark/s3bench/s3bench_DBupdate.py
@@ -202,7 +202,7 @@ def insertOperations(files,Build,Version,col,Config_ID,Branch,OS,db): #function 
                             throughput = round(throughput,6)
 
                         lat={"Max":float(lines[count-4].split(":")[1][:-2]),"Avg":float(lines[count-5].split(":")[1][:-2]),"Min":float(lines[count-3].split(":")[1][:-2])}
-                        ttfb={"Max":float(lines[count+12].split(":")[1][:-2]),"Avg":float(lines[count+11].split(":")[1][:-2]),"Min":float(lines[count+13].split(":")[1][:-2])}
+                        ttfb={"Max":float(lines[count+12].split(":")[1][:-2]),"Avg":float(lines[count+11].split(":")[1][:-2]),"Min":float(lines[count+13].split(":")[1][:-2]),"99p":float(lines[count+10].split(":")[1][:-2])}
                         data = s3bench(filename,opname,iops,throughput,lat,ttfb,obj,Build,Version,Branch,OS,nodes_num,clients_num,col,Config_ID,overwrite,sessions,Objects,pc_full,custom,Run_Health)
                     
                         if find_iteration:
@@ -336,5 +336,3 @@ def main(argv):
 
 if __name__=="__main__":
     main(sys.argv) 
-
-#!/usr/bin/env python3


### PR DESCRIPTION
This PR addresses PerfPro backend changes for adding new metric TTFB 99% to S3bench DB data.
This adds a new key 99p to DB records for S3bench TTFB data which will be used by PerfPro Dashboard to display TTFB 99% data for Read Requests.  

Signed-off-by: Tushar Jain <tushar.1.jain@seagate.com>