### PR TITLE
EOS-26068 : Setting ulimit -n 100000 on client systems

### DIFF
--- a/performance/PerfPro/roles/benchmark/files/PerfProBenchmark/set_ulimit.sh
+++ b/performance/PerfPro/roles/benchmark/files/PerfProBenchmark/set_ulimit.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+mylimit=`cat ~/.bashrc | grep 'ulimit' | awk '{print $3}'`
+if [ -z $mylimit ]
+  then
+    echo "*** Appending ulimit to bashrc ***"
+    echo "ulimit -n 100000" >> ~/.bashrc
+    echo "*** Appended ***"
+elif [ $mylimit -eq 100000 ]
+  then
+    echo "*** Ulimit is already set to 100000 ***"
+    echo "*** Nothing to modify ***"
+else
+    echo "*** Modifying ulimit value in bashrc ***"
+    sed -i "s/ulimit -n $mylimit/ulimit -n 100000/" ~/.bashrc
+    echo "*** Modified ***"
+fi
+
+echo "*** Loading bashrc ***"
+echo "*** Loaded ***"
+source ~/.bashrc
+echo "*** Old ulimit value: $mylimit ***"
+echo "*** New ulimit value: `ulimit -n` ***"
+

--- a/performance/PerfPro/roles/benchmark/tasks/main.yml
+++ b/performance/PerfPro/roles/benchmark/tasks/main.yml
@@ -28,6 +28,11 @@
    with_items: "{{ groups['nodes'] }}"
    when: SYSTEM_STATS
 
+ - name: Setting up ulimit as 100000 on Clients
+   shell: /root/PerfProBenchmark/set_ulimit.sh
+   delegate_to: "{{ item }}"
+   with_items: "{{ groups['clients'] }}"
+
  - name: copying config.yml file to Clients
    copy:
      src: roles/benchmark/vars/config.yml


### PR DESCRIPTION
Created a script which will run on each client and set ulimit value to 100000.
Signed-off-by: Rajesh Deshmukh <rajesh.deshmukh@seagate.com>