### PR TITLE
EOS-26138: Updated logic for getconfig() for selection of collection

### DIFF
--- a/performance/PerfPro/roles/benchmark/files/PerfProBenchmark/copy_object/s3bench_DBupdate.py
+++ b/performance/PerfPro/roles/benchmark/files/PerfProBenchmark/copy_object/s3bench_DBupdate.py
@@ -27,6 +27,7 @@ configs_main = makeconfig(Main_path)
 configs_config= makeconfig(Config_path)
 
 build_url=configs_config.get('BUILD_URL')
+
 nodes_list=configs_config.get('NODES')
 clients_list=configs_config.get('CLIENTS')
 pc_full=configs_config.get('PC_FULL')
@@ -283,6 +284,7 @@ def getconfig():
     custom=configs_config.get('CUSTOM')
     overwrite=configs_config.get('OVERWRITE')
     cluster_pass=configs_config.get('CLUSTER_PASS')
+    solution=configs_config.get('SOLUTION')
     change_pass=configs_config.get('CHANGE_PASS')
     prv_cli=configs_config.get('PRVSNR_CLI_REPO')
     prereq_url=configs_config.get('PREREQ_URL')
@@ -293,7 +295,7 @@ def getconfig():
     nfs_mp=configs_config.get('NFS_MOUNT_POINT')
     nfs_fol=configs_config.get('NFS_FOLDER')
 
-    dic={'NODES' :str(nodes_list) , 'CLIENTS' : str(clients_list) ,'BUILD_URL': build_url ,'CLUSTER_PASS': cluster_pass ,'CHANGE_PASS': change_pass ,'PRVSNR_CLI_REPO': prv_cli ,'PREREQ_URL': prereq_url ,'SERVICE_USER': srv_usr ,'SERVICE_PASS': srv_pass , 'PC_FULL': pc_full , 'CUSTOM': custom , 'OVERWRITE':overwrite ,'NFS_SERVER': nfs_serv ,'NFS_EXPORT' : nfs_exp ,'NFS_MOUNT_POINT' : nfs_mp , 'NFS_FOLDER' : nfs_fol }
+    dic={'NODES' :str(nodes_list) , 'CLIENTS' : str(clients_list) ,'BUILD_URL': build_url ,'CLUSTER_PASS': cluster_pass , 'SOLUTION': solution , 'CHANGE_PASS': change_pass ,'PRVSNR_CLI_REPO': prv_cli ,'PREREQ_URL': prereq_url ,'SERVICE_USER': srv_usr ,'SERVICE_PASS': srv_pass , 'PC_FULL': pc_full , 'CUSTOM': custom , 'OVERWRITE':overwrite ,'NFS_SERVER': nfs_serv ,'NFS_EXPORT' : nfs_exp ,'NFS_MOUNT_POINT' : nfs_mp , 'NFS_FOLDER' : nfs_fol }
     return (dic)
 
 
@@ -310,14 +312,22 @@ def main(argv):
     Branch=Branch[1:-1]
     OS=get_release_info('OS')
     OS=OS[1:-1]
-    col_config=configs_main.get('R'+Version[0])['config_collection']
     dic = getconfig()
+    if dic['SOLUTION'].upper() == 'LC':
+       col=configs_main.get('LC')
+    elif dic['SOLUTION'].upper() == 'LR':
+       col=configs_main.get('LR')
+    elif dic['SOLUTION'].upper() == 'LEGACY':
+       col=configs_main.get(f"R{Version.split('.')[0]}")
+    else:
+        print("Error! Can not find suitable collection to upload data")
+
+
     Config_ID = "NA"
-    result = db[col_config].find_one(dic)    
+    result = db[col['config_collection']].find_one(dic) # find entry from configurations collection
     if result:
         Config_ID = result['_id'] # foreign key : it will map entry in configurations to results entry
-    col=configs_main.get('R'+Version[0])['db_collection']
-    insertOperations(files,Build,Version,col,Config_ID,Branch,OS,db)
+    insertOperations(files,Build,Version,col['db_collection'],Config_ID,Branch,OS,db)
 
 if __name__=="__main__":
     main(sys.argv) 

--- a/performance/PerfPro/roles/benchmark/files/PerfProBenchmark/db_scripts/hsbench_DBupdate.py
+++ b/performance/PerfPro/roles/benchmark/files/PerfProBenchmark/db_scripts/hsbench_DBupdate.py
@@ -109,6 +109,7 @@ def getconfig():
     overwrite=configs_config.get('OVERWRITE')
     custom=configs_config.get('CUSTOM')
     cluster_pass=configs_config.get('CLUSTER_PASS')
+    solution=configs_config.get('SOLUTION')
     change_pass=configs_config.get('CHANGE_PASS')
     prv_cli=configs_config.get('PRVSNR_CLI_REPO')
     prereq_url=configs_config.get('PREREQ_URL')
@@ -119,7 +120,7 @@ def getconfig():
     nfs_mp=configs_config.get('NFS_MOUNT_POINT')
     nfs_fol=configs_config.get('NFS_FOLDER')
 
-    dic={'NODES' :str(nodes_list) , 'CLIENTS' : str(clients_list) ,'BUILD_URL': build_url ,'CLUSTER_PASS': cluster_pass ,'CHANGE_PASS': change_pass ,'PRVSNR_CLI_REPO': prv_cli ,'PREREQ_URL': prereq_url ,'SERVICE_USER': srv_usr ,'SERVICE_PASS': srv_pass , 'PC_FULL': pc_full , 'CUSTOM': custom , 'OVERWRITE':overwrite , 'NFS_SERVER': nfs_serv ,'NFS_EXPORT' : nfs_exp ,'NFS_MOUNT_POINT' : nfs_mp , 'NFS_FOLDER' : nfs_fol }
+    dic={'NODES' :str(nodes_list) , 'CLIENTS' : str(clients_list) ,'BUILD_URL': build_url ,'CLUSTER_PASS': cluster_pass , 'SOLUTION': solution , 'CHANGE_PASS': change_pass ,'PRVSNR_CLI_REPO': prv_cli ,'PREREQ_URL': prereq_url ,'SERVICE_USER': srv_usr ,'SERVICE_PASS': srv_pass , 'PC_FULL': pc_full , 'CUSTOM': custom , 'OVERWRITE':overwrite , 'NFS_SERVER': nfs_serv ,'NFS_EXPORT' : nfs_exp ,'NFS_MOUNT_POINT' : nfs_mp , 'NFS_FOLDER' : nfs_fol }
     return (dic)
 
 ##Function to find latest iteration
@@ -160,14 +161,23 @@ def push_data(files, host, db, Build, Version, Branch , OS):
     iteration_number = 0
     global nodes_num, clients_num, pc_full , overwrite, custom
     print("logged in from ", host)
-    collection=configs_main.get('R'+Version[0])['db_collection']
-    col_config =configs_main.get('R'+Version[0])['config_collection']
     dic = getconfig()
-    result = db[col_config].find_one(dic)  # find entry from configurations collection
+    if dic['SOLUTION'].upper() == 'LC':
+       valid_col=configs_main.get('LC')
+    elif dic['SOLUTION'].upper() == 'LR':
+       valid_col=configs_main.get('LR')
+    elif dic['SOLUTION'].upper() == 'LEGACY':
+       valid_col=configs_main.get(f"R{Version.split('.')[0]}")
+    else:
+        print("Error! Can not find suitable collection to upload data")
+
+    result = db[valid_col['config_collection']].find_one(dic)  # find entry from configurations collection
     Config_ID = "NA"
     if result:
         Config_ID = result['_id'] # foreign key : it will map entry in configurations to results entry
-    
+   
+    collection=valid_col['db_collection']
+
     for doc in files:
         data_dict = None
         try:

--- a/performance/PerfPro/roles/benchmark/files/PerfProBenchmark/system_monitoring/systemMonitoring.py
+++ b/performance/PerfPro/roles/benchmark/files/PerfProBenchmark/system_monitoring/systemMonitoring.py
@@ -79,16 +79,16 @@ def makeconnection(collection):  #function for making connection with database
     client = MongoClient(configs['db_url'])  #connecting with mongodb database
     db=client[configs['db_database']]  #database name=performance
     if solution.upper() == 'LC':
-        col_stats=configs.get(LC)[collection]
+        col_stats=configs.get('LC')[collection]
     elif solution.upper() == 'LR':
-        col_stats=configs.get(LR)[collection]
+        col_stats=configs.get('LR')[collection]
     elif solution.upper() == 'LEGACY':
        Version=get_release_info('VERSION')
        Version=Version[1:-1]
        col_stats=configs.get('R'+Version[0])[collection]
     else:
         print("Error! Can not find suitable collection to upload data")
-    col=db[col_stats]  #collection name = systemresults
+    col=db[col_stats]  #collection name = configurations
     return col
 def getconfig():
     nodes_list=configs_config.get('NODES')


### PR DESCRIPTION
Validated getconfig() code as follows

PerfProBenchmark/addconfiguration.py						=> validated
PerfProBenchmark/copy_object/s3bench_DBupdate.py			=> validated
PerfProBenchmark/system_monitoring/systemMonitoring.py	=> modified
PerfProBenchmark/cosbench/cosbench_DBupdate.py			=> Coult not check as Cosbench is failing on k8s env
PerfProBenchmark/s3bench/s3bench_DBupdate.py			=> validated
PerfProBenchmark/hsbench/hsbench_DBupdate.py			=> validated
PerfProBenchmark/db_scripts/hsbench_DBupdate.py			=> validated
PerfProBenchmark/db_scripts/s3bench_DBupdate.py			=> validated
