### PR TITLE
EOS-28423: Moved package installation post establishing ssh

### DIFF
--- a/performance/PerfPro/roles/benchmark/tasks/passwordless_ssh.yml
+++ b/performance/PerfPro/roles/benchmark/tasks/passwordless_ssh.yml
@@ -4,21 +4,6 @@
       name: expect
       state: present
 
- - name: "[Clients] : Installing Required Packages on Clients"
-   yum:
-      name: expect
-      state: present
-   delegate_to: "{{ item }}"
-   with_items: "{{ groups['clients'] }}"
-
- - name: "[Nodes] : Required packages on Nodes"
-   yum:
-      name: expect
-      state: present
-   delegate_to: "{{ item }}"
-   with_items: "{{ groups['nodes'] }}"
-   when: SYSTEM_STATS
-
  - name: "[Orchestrator(localhost)] : Generating SSH key pair if not exist"
    openssh_keypair:
       path: "~/.ssh/id_rsa"

--- a/performance/PerfPro/roles/benchmark/tasks/prepare_setup.yml
+++ b/performance/PerfPro/roles/benchmark/tasks/prepare_setup.yml
@@ -2,6 +2,7 @@
  - name: "Installing required yum packages on clients"
    yum:
      name:
+       - expect
        - ntp
        - python3
        - python3-pip
@@ -18,6 +19,7 @@
  - name: "Installing required yum packages on nodes"
    yum:
      name:
+       - expect
        - ntp
        - sysstat
        - python3


### PR DESCRIPTION
The "expect" package requirement was getting handled before establishing ssh channel to client and nodes. Moved that task after establishing the channel. 