### PR TITLE
CORTX-28290: Collect ADDB data for last N hour/minute/second

### DIFF
--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/core/tasks.py
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/core/tasks.py
@@ -80,6 +80,9 @@ def parse_options(conf, result_dir):
     if 'analyze_addb' in conf['execution_options']:
         if conf['execution_options']['analyze_addb']:
             options.append("--addb-analyze")
+    if 'addb_duration' in conf['execution_options']:
+        options.append("--addb-duration")
+        options.append(conf['execution_options']['addb_duration'])
     if conf['execution_options']['backup_result']:
         options.append("--backup-result")
 

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/core/validator.py
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/core/validator.py
@@ -301,6 +301,7 @@ def get_schema_motr():
                 'collect_m0trace': {'type': 'boolean'},
                 'collect_addb': {'type': 'boolean'},
                 'analyze_addb': {'type': 'boolean', 'required': False},
+                'addb_duration': {'type': 'string', 'required': False, 'empty': False, 'regex': '(^all$)|(^\d+((m$)|(h$)|(s$)|(min$)|(sec$)|(hr$)|(hour$)|(minute$)|(second$))$)'},
                 'backup_result': {'type': 'boolean'}
             }
         }

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/LC/s3srv_artifacts.sh
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/LC/s3srv_artifacts.sh
@@ -112,6 +112,7 @@ function save_s3srv_artifacts() {
         mkdir -p $dumps_dir
         pushd $dumps_dir
         save_s3_addb
+        fiter_addb_dumps "s3server"
         generate_s3_m0play
         popd			# $dumps_dir
     fi

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/worker.sh
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/worker.sh
@@ -182,12 +182,12 @@ function stop_stat_utils()
 
 function start_measuring_workload_time()
 {
-    WORKLOAD_TIME_START_SEC=$(date +'%s')
+    WORKLOAD_TIME_START_SEC=`date +'%s'`
 }
 
 function stop_measuring_workload_time()
 {
-    WORKLOAD_TIME_STOP_SEC=$(date +'%s')
+    WORKLOAD_TIME_STOP_SEC=`date +'%s'`
     local stats="stats"
     mkdir -p $stats
     pushd $stats
@@ -283,8 +283,8 @@ function main() {
     collect_stat_data
 
     # Start stat utilities
-   echo "Start stat utilities"
-   start_stat_utils
+    echo "Start stat utilities"
+    start_stat_utils
 
     # Start workload time execution measuring
     start_measuring_workload_time
@@ -301,7 +301,6 @@ function main() {
     save_cluster_status
     stop_cluster
 
-    
     # Collect ADDBs/m0traces/m0play.db
     collect_artifacts
 
@@ -364,7 +363,7 @@ while [[ $# -gt 0 ]]; do
         -d|--addb-dumps)
             ADDB_DUMPS="1"
             ;;
-	--addb-analyze)
+	    --addb-analyze)
             ADDB_ANALYZE="1"
             ;;
         --motr-trace)
@@ -384,6 +383,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --backup-result)
             BACKUP_RESULT="1"
+            ;;
+        --addb-duration)
+            ADDB_DURATION=$2
+            shift
             ;;
         *)
             echo -e "Invalid option: $1\nUse --help option"

--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/workload/example.yaml
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/workload/example.yaml
@@ -125,4 +125,6 @@ execution_options:
   mkfs: false
   collect_m0trace: false
   collect_addb: false
+  addb_duration: 5 min         # This options would be required to filter last N hour/minute/second addb dump
+  analyze_addb: false
   backup_result: false


### PR DESCRIPTION
Addition of new functionality as a part of perfline to collect addb data
for last N hour/minute/second based on workload execution load/time.
User can mention "addb_duration: all/5min/1hr/25sec" as a part of
execution_options in their workload yaml file.
Ex:
```
    default configuration:
    addb_duration: all

    As per usage, user can modify like below if they wanted to collect last 5 minute:
    addb_duration: 5min
```

Signed-off-by: Rahul Kumar <rahul.kumar@seagate.com>