### PR TITLE
CORTX-31189 : Reduced user sessions to 30 and 45 for sanity workload

### DIFF
--- a/performance/PerfPro/roles/benchmark/vars/s3config.yml
+++ b/performance/PerfPro/roles/benchmark/vars/s3config.yml
@@ -1,7 +1,7 @@
 ---
 sanity_low_load:
    sessions:
-      - 300
+      - 30
    objs:
       - { objsize: '256Kb', numsamples: '180000'}
       - { objsize: '16Mb', numsamples: '18000'}
@@ -9,7 +9,7 @@ sanity_low_load:
 
 sanity_high_load:
    sessions:
-      - 450
+      - 45
    objs:
       - { objsize: '128Mb', numsamples: '2250'}
 


### PR DESCRIPTION
Signed-off-by: Rajesh Deshmukh <rajesh.deshmukh@seagate.com>

Changes:
Perf-sanity fails due to limitation from Cortx side. With that limitations, restricting the number of sessions for sanity workload. Updated the sessions to 30(min) and 45(max) considering 3-node setup.