### PR TITLE
CORTX-31653: removed 3rd party deps URL from LC/update.sh

### DIFF
--- a/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/LC/update.sh
+++ b/performance/PerfLine/roles/perfline_setup/files/wrapper/scripts/LC/update.sh
@@ -107,7 +107,6 @@ function checkout() {
 }
 
 function build_rpms() {
-    local repo_3rd_party="http://cortx-storage.colo.seagate.com/releases/cortx/third-party-deps/rockylinux/rockylinux-8.4-2.0.0-latest/"
     local rpmbuild_dir="$DOCKER_BUILD_DIR/rpmbuild"
 
     # 'Clean' phase
@@ -128,10 +127,7 @@ function build_rpms() {
         -v "$rpmbuild_dir":/root/rpmbuild \
         -v "$RPM_DIR":/var/artifacts \
         -v "$CORTX_SRC_DIR":/cortx-workspace \
-        $CORTX_BUILD_IMAGE sh -c "yum-config-manager --add-repo=$repo_3rd_party \
-            && yum --nogpgcheck -y --disablerepo='baseos' --disablerepo='powertools' \
-            install libfabric libfabric-devel \
-            && make cortx-all-rockylinux-image"
+        "$CORTX_BUILD_IMAGE" make cortx-all-rockylinux-image
 }
 
 function build_image() {


### PR DESCRIPTION
Old versions of 'cortx-build' docker image was not able to build Motr properly.
The reason was that Motr building process didn't include required installation
of 'libfabric' and 'libfabric-devel' packages as prerequisites.
In order to be able to build Motr properly it was added small workaround for
libfabric packages installation before build process is started. Latest
versions of 'cortx-build' images already contain this step as a prerequisite.
That's why described workaround is not required anymore.

Signed-off-by: Alexander Sukhachev <alexander.sukhachev@seagate.com>