### PR TITLE
removed hardcoded value of CORTX_K8S_REPO variable

### DIFF
--- a/performance/PerfLine/inventories/perfline_hosts/hosts
+++ b/performance/PerfLine/inventories/perfline_hosts/hosts
@@ -22,7 +22,8 @@ enable_daemon_service='no'
 perfline_ui_port=8005
 
 
-# Disk input would be required for LC setup
+# Required for LC setup
+cortx_k8s_repo=""
 disk=""
 
 cortx_re_repo="/root/cortx-re"

--- a/performance/PerfLine/readme.md
+++ b/performance/PerfLine/readme.md
@@ -14,7 +14,7 @@ PerfLine can be installed from any machine. Below prerequisites must be satisfie
 1.  Please follow below link to deploy CORTX cluster using the services framework:
     [service_framework](https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/754155622/CORTX+Kubernetes+Deployment+Document+using+Services+Framework)
 
-    Stable version of `cortx-k8s` repository is required to clone into `/root/cortx-k8s` directory of primary server node.
+    Stable version of `cortx-k8s` repository has to be cloned into any directory (for example `/root/deploy-scripts`) of primary server node.
     It's recommended to use version v0.8.0 (commit d680cdacaf2e6b74745e913b38efcca354f3cc54) of `cortx-k8s`.
 
     NOTE:  starting from `cortx-k8s` v0.1.0 the default s3 application is RGW. In case if you need to use
@@ -64,6 +64,14 @@ PerfLine can be installed from any machine. Below prerequisites must be satisfie
     **Note : It's mandatory to use common password for all.**
 
         cluster_pass=
+
+    5.5  Specify both `cortx_k8s_repo` and `disk` variables.
+    **Note : It's required only for LC setup.**
+
+    Example:
+
+        cortx_k8s_repo="/root/deploy-scripts"
+        disk="/dev/sdb"
 
 ## Installation
 

--- a/performance/PerfLine/roles/perfline_setup/files/perfline.conf
+++ b/performance/PerfLine/roles/perfline_setup/files/perfline.conf
@@ -45,9 +45,7 @@ CLUSTER_TYPE="LC"
 # starting from cortx-k8s v0.1.0 default s3 application is RGW
 S3_APP="rgw" # supported values are [s3srv, rgw]
 DISK=""
-# TODO: Ansible scripts have to be updated.
-# CORTX_K8S_REPO variable is required only for LC clusters
-CORTX_K8S_REPO="/root/cortx-k8s"
+CORTX_K8S_REPO=""
 
 CORTX_RE_REPO=""
 CORTX_BUILD_IMAGE=""

--- a/performance/PerfLine/roles/perfline_setup/tasks/pre-req_perfline.yml
+++ b/performance/PerfLine/roles/perfline_setup/tasks/pre-req_perfline.yml
@@ -89,6 +89,7 @@
        - { variable: 'BACKUP_NFS_LOCATION', value: '{{ backup_nfs_location }}'}
        - { variable: 'STORAGE_CONTROLLER_LOGIN', value: '{{ storage_controller_login }}'}
        - { variable: 'STORAGE_CONTROLLER_PASSWORD', value: '{{ storage_controller_password }}'}
+       - { variable: 'CORTX_K8S_REPO', value: '{{ cortx_k8s_repo }}'}
 
   - name: "Updating numeric values of a variables in perfline.conf"
     lineinfile:


### PR DESCRIPTION
perfline.conf file contains CORTX_K8S_REPO
variable that has to have a value according to
the location of cortx-k8s repository on a cluster.
User is responsible to assign a proper proper value.

Previous versions of PerfLine had hardcoded value
of CORTX_K8S_REPO. As a result user had to update
this variable once PerfLine installation is completed.

This patch allows user to specify proper value in
the inventories/perfline_hosts/hosts file before
installation.

Signed-off-by: Alexander Sukhachev <alexander.sukhachev@seagate.com>

-----
[View rendered performance/PerfLine/readme.md](https://github.com/alexsukhachev/seagate-tools/blob/perfline_improvements/performance/PerfLine/readme.md)