### PR TITLE
CORTX-33714: Make use of default ssh key for passwordless authentication

### DIFF
--- a/performance/PerfLine/VERSION
+++ b/performance/PerfLine/VERSION
@@ -1,1 +1,1 @@
-VERSION perfline_v0.3.1
+VERSION perfline_v0.3.2

--- a/performance/PerfLine/ansible.cfg
+++ b/performance/PerfLine/ansible.cfg
@@ -151,7 +151,7 @@ log_path = /var/log/ansible.log
 
 # if set, always use this private key file for authentication, same as
 # if passing --private-key to ansible or ansible-playbook
-private_key_file = /root/.ssh/id_rsa_perfline
+private_key_file = /root/.ssh/id_rsa
 
 # If set, configures the path to the Vault password file as an alternative to
 # specifying --vault-password-file on the command line.
@@ -437,8 +437,8 @@ private_key_file = /root/.ssh/id_rsa_perfline
 # only be disabled if your sftp version has problems with batch mode
 #sftp_batch_mode = False
 
-# The -tt argument is passed to ssh when pipelining is not enabled because sudo 
-# requires a tty by default. 
+# The -tt argument is passed to ssh when pipelining is not enabled because sudo
+# requires a tty by default.
 #usetty = True
 
 # Number of times to retry an SSH connection to a host, in case of UNREACHABLE.

--- a/performance/PerfLine/roles/perfline_setup/files/chronometry/addb2db.py
+++ b/performance/PerfLine/roles/perfline_setup/files/chronometry/addb2db.py
@@ -77,7 +77,7 @@ import json
 
 DB      = SqliteDatabase(None)
 BLOCK   = 32<<10
-DBBATCH = 777
+DBBATCH = 50
 PID     = 0
 
 def die(what: str):

--- a/performance/PerfLine/roles/perfline_setup/files/passwordless_ssh.sh
+++ b/performance/PerfLine/roles/perfline_setup/files/passwordless_ssh.sh
@@ -22,7 +22,7 @@
 
 
 # ./passwordless_ssh.sh node username pass
-spawn ssh-copy-id -i /root/.ssh/id_rsa_perfline -o "StrictHostKeyChecking=no" [lindex $argv 0]@[lindex $argv 1]
+spawn ssh-copy-id -i /root/.ssh/id_rsa -o "StrictHostKeyChecking=no" [lindex $argv 0]@[lindex $argv 1]
 set timeout 10
 expect {
     timeout {

--- a/performance/PerfLine/roles/perfline_setup/tasks/enable_passwordless.yml
+++ b/performance/PerfLine/roles/perfline_setup/tasks/enable_passwordless.yml
@@ -26,7 +26,7 @@
 
  - name: "[local-pre-req] : Generate SSH key 'id_rsa' on localhost"
    openssh_keypair:
-      path: "~/.ssh/id_rsa_perfline"
+      path: "~/.ssh/id_rsa"
       type: rsa
       size: 4096
       state: present
@@ -46,7 +46,7 @@
 
  - name: "[cluster-pre-req] : Generate SSH key 'id_rsa' to all servers"
    openssh_keypair:
-      path: "~/.ssh/id_rsa_perfline"
+      path: "~/.ssh/id_rsa"
       type: rsa
       size: 4096
       state: present
@@ -69,7 +69,7 @@
  - name: "[client-pre-req] : Adding Identityfile on /etc/ssh/ssh_config file"
    lineinfile:
       path: "/etc/ssh/ssh_config"
-      line: "\tIdentityFile ~/.ssh/id_rsa_perfline"
+      line: "\tIdentityFile ~/.ssh/id_rsa"
    delegate_to: "{{ item }}"
    with_items: "{{ groups['all'] }}"
 


### PR DESCRIPTION
## Problem Statement

Currently we are using perfline ssh-key to enable passwordless authentication which is currently broken. It would be a best practice to make use of existing or default ssh-key which already reside in the server and if this is not available then only perfline will create for user to avoid disruption on their servers.


## Coding

-   [x] Coding conventions are followed and code is consistent
-   [x] No new Codacy Issues are added
-   [x] Version is updated in the respective VERSION file, format - `<tool>_v<major>.<minor>.<patch>`

## Documentation

-   [ ] Changes done to readme file / Quick Start Guide
-   [ ] Docstrings are added to new functions/ files with Summary, Args and Return params

## Testing

-   [x] New/Affected tests are executed on Latest Build
-   [ ] Attach test execution logs
-   [ ] No regression introduced

## Pull Request

-   [x] JIRA number/GitHub Issue added to PR, format - `<ID>: <Title>`
-   [x] Only one commit is present, format -
    ```txt
     commit 7c76b206590e1565fe1f5a656cd73882b31ac9b4
     Author: Rahul Kumar <rahul.kumar@seagate.com>
     Date:   Wed Jul 20 04:56:28 2022 -0600

     CORTX-33714: Make use of default ssh key for passwordless authentication

     Signed-off-by: Rahul Kumar <rahul.kumar@seagate.com>

    ```
-   [x] Commit is sign-offed

## Review Checklist

-   [x] PR is self reviewed
-   [x] JIRA ticket state/status is updated
-   [x] Check if the DoD, description is clear and explained

## Impact Analysis

  (Checklist for Author/Reviewer/GateKeeper)

-   [ ] Are there any changes in any common function?

  If yes,

-   [ ] Relative/ dependent function calls are updated
-   [ ] Executed all affected tests

> Note: If checkboxes are not working, write Y/N in front of the bullets. Thanks for your contribution and Happy Coding!


Signed-off-by: Rahul Kumar <rahul.kumar@seagate.com>