### PR TITLE
CORTX-33075: [Perf-Sanity] Fix /all not displaying data on fresh load

### DIFF
--- a/dashboards/perf-rest/rest_app/sanity.py
+++ b/dashboards/perf-rest/rest_app/sanity.py
@@ -236,7 +236,7 @@ class highConcurrencyData(Resource):
 
         results = deepcopy(schemas.results_format)
 
-        _, record_id = sanityapi.get_baseline_index(uri, request_runid)
+        _, record_id = sanityapi.get_baseline_index(uri, json_data["run_id"])
 
         value_query = {"run_ID": json_data["run_id"],
                        "Sessions": read_config.sanity_high_conc_sessions,
@@ -251,7 +251,7 @@ class highConcurrencyData(Resource):
 
         if rp_status and wp_status:
             results["difference"] = {
-                key: results['value'][key] - results['baseline'].get(key, 0) for key in results['value']
+                key: round(results['value'][key] - results['baseline'].get(key, 0), 3) for key in results['value']
             }
         else:
             results["difference"] = {

--- a/dashboards/perf-rest/setup.py
+++ b/dashboards/perf-rest/setup.py
@@ -21,4 +21,4 @@
 
 from setuptools import setup, find_packages
 
-setup(name='Perf-Rest', version='0.2.0', packages=find_packages())
+setup(name='Perf-Rest', version='0.2.1', packages=find_packages())

--- a/dashboards/superperf/VERSION
+++ b/dashboards/superperf/VERSION
@@ -1,1 +1,1 @@
-VERSION superperf_v0.2.0
+VERSION superperf_v0.2.1


### PR DESCRIPTION
## Problem Statement
The high Concurrency table is not showing data on a fresh load. Throws no IndexError: no such item for cursor instance.
side fix: rounded off difference row for the same table

Signed-off-by: Sampada Petkar <sampada.petkar@seagate.com>

## Design

Accessed run_id from converted JSON from API response

## Coding

-   [x] Coding conventions are followed and code is consistent
-   [x] No new Codacy Issues are added
-   [x] Version is updated in the respective VERSION file

## Documentation

-   [x] Changes done to readme file / Quick Start Guide
-   [x] Docstrings are added to new functions/ files with Summary, Args and Return params

## Testing

-   [x] New/Affected tests are executed on Latest Build
-   [x] Attach test execution logs
-   [x] No regression introduced

## Pull Request

-   [x] JIRA number/GitHub Issue added to PR, format - `<ID>: <Title>`
-   [x] Only one commit is present

## Review Checklist

-   [x] PR is self reviewed
-   [x] JIRA ticket state/status is updated
-   [x] Check if the DoD, description is clear and explained

## Impact Analysis

  (Checklist for Author/Reviewer/GateKeeper)

-   [ ] Are there any changes in any common function?

  If yes,

-   [ ] Relative/ dependent function calls are updated
-   [ ] Executed all affected tests

> Note: If checkboxes are not working, write Y/N in front of the bullets. Thanks for your contribution and Happy Coding!
